### PR TITLE
fix(admin-api): eliminate wildcard CORS with credentials (security #111)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### 🔒 Security
+
+#### CORS hardening on admin-api — no more wildcard with credentials (#111)
+- **Removed** the permissive `allow_origins=['*']` fallback and the
+  `allow_methods/headers/expose_headers=['*']` wildcards from the
+  `admin_api.py` entrypoint. Combined with `allow_credentials=True` those
+  wildcards constituted a CORS bypass.
+- **Added** a shared helper `admin-api/app/core/cors.py:configure_cors()`
+  used by **both** `main.py` and `admin_api.py` so the two entrypoints
+  can no longer drift.
+- **Breaking for operators**: `CORS_ORIGINS` is now required. The service
+  refuses to start on empty or wildcard values. Ops action: set
+  `CORS_ORIGINS=http://localhost:3000,https://app.example.com` (or your
+  real origins) before deploying.
+
 ## [2.1.0.0] - 2025-11-11
 
 ### ✨ Features

--- a/admin-api/admin_api.py
+++ b/admin-api/admin_api.py
@@ -13,10 +13,10 @@ from app.api.v1.api import api_router
 from app.api.v1.endpoints.auth import User, get_current_user
 from app.api.v1.endpoints.dashboard import periodic_follower_update_task
 from app.core.config import get_settings
+from app.core.cors import configure_cors
 from app.db.mongodb import close_mongo_connection, connect_to_mongo
 from app.services.follower_service import FollowerService
 from fastapi import Depends, FastAPI, HTTPException, status
-from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import JSONResponse
 from spreadpilot_core.logging.logger import get_logger, setup_logging
 
@@ -79,19 +79,9 @@ app = FastAPI(
     openapi_url="/openapi.json",
 )
 
-# Configure CORS middleware
-app.add_middleware(
-    CORSMiddleware,
-    allow_origins=(
-        [origin.strip() for origin in settings.cors_origins.split(",")]
-        if settings.cors_origins
-        else ["*"]
-    ),
-    allow_credentials=True,
-    allow_methods=["*"],
-    allow_headers=["*"],
-    expose_headers=["*"],
-)
+# Configure CORS middleware (fail-fast on empty/wildcard origins; see #111)
+allowed_origins = configure_cors(app, settings)
+logger.info(f"CORS configured with {len(allowed_origins)} allowed origins")
 
 
 @app.exception_handler(HTTPException)

--- a/admin-api/app/core/config.py
+++ b/admin-api/app/core/config.py
@@ -15,8 +15,10 @@ class Settings(BaseModel):
     # API configuration
     api_v1_prefix: str = "/api/v1"
 
-    # CORS configuration
-    cors_origins: str = "*"
+    # CORS configuration. Empty by default — the real value must come from
+    # CORS_ORIGINS env var. A wildcard here would be a loaded gun one
+    # constructor call away from shipping (see issue #111).
+    cors_origins: str = ""
 
     # MongoDB configuration
     mongo_uri: str = os.getenv("MONGO_URI", "")
@@ -67,8 +69,12 @@ class Settings(BaseModel):
         if self.jwt_secret and len(self.jwt_secret) < 32:
             missing_secrets.append("JWT_SECRET (too short - minimum 32 characters required)")
 
-        # Validate CORS is not wildcard
-        if self.cors_origins == "*":
+        # Validate CORS_ORIGINS is set and not a wildcard. Empty-string check
+        # catches the case where the env var is unset; wildcard check covers
+        # explicit `*` or an all-whitespace value (see issue #111).
+        if not self.cors_origins or not self.cors_origins.strip():
+            missing_secrets.append("CORS_ORIGINS (must be set; wildcard not allowed)")
+        elif self.cors_origins.strip() == "*":
             missing_secrets.append("CORS_ORIGINS (wildcard not allowed)")
 
         # Validate Redis URL

--- a/admin-api/app/core/cors.py
+++ b/admin-api/app/core/cors.py
@@ -5,6 +5,7 @@ Centralising the CORS middleware setup here prevents the two entrypoints
 shipped a permissive `allow_origins=['*']` fallback with `allow_credentials=True`,
 which is a CORS bypass (see issue #111).
 """
+
 from __future__ import annotations
 
 from typing import Protocol

--- a/admin-api/app/core/cors.py
+++ b/admin-api/app/core/cors.py
@@ -23,11 +23,14 @@ class _SettingsLike(Protocol):
 
 
 def configure_cors(app: FastAPI, settings: _SettingsLike) -> list[str]:
-    """Validate CORS_ORIGINS and register CORSMiddleware.
+    """Validate CORS_ORIGINS and register CORSMiddleware on `app`.
 
-    Raises ValueError (fail-fast) if `settings.cors_origins` is unset or
-    contains the wildcard `*`. Returns the parsed list of allowed origins
-    for logging / testing purposes.
+    Side effect: calls `app.add_middleware(CORSMiddleware, ...)` with an
+    explicit methods/headers allowlist and `allow_credentials=True`.
+
+    Raises ValueError (fail-fast) if `settings.cors_origins` is empty,
+    whitespace-only, or contains the wildcard `*`. Returns the parsed
+    list of allowed origins for logging / testing purposes.
     """
     raw = (settings.cors_origins or "").strip()
     if not raw:
@@ -49,6 +52,8 @@ def configure_cors(app: FastAPI, settings: _SettingsLike) -> list[str]:
     app.add_middleware(
         CORSMiddleware,
         allow_origins=origins,
+        # Required for JWT bearer-token cookies and the Authorization header.
+        # Safe because wildcard origins are rejected above.
         allow_credentials=True,
         allow_methods=ALLOWED_METHODS,
         allow_headers=ALLOWED_HEADERS,

--- a/admin-api/app/core/cors.py
+++ b/admin-api/app/core/cors.py
@@ -1,0 +1,56 @@
+"""Shared CORS configuration for admin-api entrypoints.
+
+Centralising the CORS middleware setup here prevents the two entrypoints
+(`main.py` and `admin_api.py`) from drifting apart — historically `admin_api.py`
+shipped a permissive `allow_origins=['*']` fallback with `allow_credentials=True`,
+which is a CORS bypass (see issue #111).
+"""
+from __future__ import annotations
+
+from typing import Protocol
+
+from fastapi import FastAPI
+from fastapi.middleware.cors import CORSMiddleware
+
+# Explicit allowlists — no wildcards. HEAD/PATCH are intentionally excluded;
+# add them here if a concrete endpoint requires them.
+ALLOWED_METHODS: list[str] = ["GET", "POST", "PUT", "DELETE", "OPTIONS"]
+ALLOWED_HEADERS: list[str] = ["Content-Type", "Authorization"]
+
+
+class _SettingsLike(Protocol):
+    cors_origins: str
+
+
+def configure_cors(app: FastAPI, settings: _SettingsLike) -> list[str]:
+    """Validate CORS_ORIGINS and register CORSMiddleware.
+
+    Raises ValueError (fail-fast) if `settings.cors_origins` is unset or
+    contains the wildcard `*`. Returns the parsed list of allowed origins
+    for logging / testing purposes.
+    """
+    raw = (settings.cors_origins or "").strip()
+    if not raw:
+        raise ValueError(
+            "CORS_ORIGINS must be set via environment variable. "
+            "Wildcard (*) is not allowed for security. "
+            "Example: CORS_ORIGINS=http://localhost:3000,https://app.example.com"
+        )
+
+    origins = [o.strip() for o in raw.split(",") if o.strip()]
+
+    if "*" in origins:
+        raise ValueError(
+            "Wildcard (*) is not allowed in CORS_ORIGINS. "
+            "Specify explicit allowed origins "
+            "(e.g., http://localhost:3000,https://app.example.com)."
+        )
+
+    app.add_middleware(
+        CORSMiddleware,
+        allow_origins=origins,
+        allow_credentials=True,
+        allow_methods=ALLOWED_METHODS,
+        allow_headers=ALLOWED_HEADERS,
+    )
+    return origins

--- a/admin-api/docker-compose.yml
+++ b/admin-api/docker-compose.yml
@@ -24,7 +24,7 @@ services:
       - ADMIN_USERNAME=${ADMIN_USERNAME:-admin}
       - ADMIN_PASSWORD_HASH=${ADMIN_PASSWORD_HASH}
       - JWT_SECRET=${JWT_SECRET:-testsecret}
-      - CORS_ORIGINS=${CORS_ORIGINS:-*}
+      - CORS_ORIGINS=${CORS_ORIGINS:?CORS_ORIGINS must be set explicitly (comma-separated list). Wildcard is not allowed — see issue #111.}
     volumes:
       - ./credentials:/app/credentials
       - ./spreadpilot-core:/app/spreadpilot-core

--- a/admin-api/main.py
+++ b/admin-api/main.py
@@ -5,10 +5,10 @@ from contextlib import asynccontextmanager
 from app.api.v1.api import api_router
 from app.api.v1.endpoints.dashboard import periodic_follower_update_task
 from app.core.config import get_settings
+from app.core.cors import configure_cors
 from app.db.mongodb import close_mongo_connection, connect_to_mongo
 from app.services.follower_service import FollowerService
 from fastapi import FastAPI
-from fastapi.middleware.cors import CORSMiddleware
 
 try:
     from spreadpilot_core.dry_run import DryRunConfig
@@ -102,48 +102,10 @@ Manual operations additionally require PIN verification.
     ],
 )
 
-# Configure CORS - STRICT: No wildcard allowed
-# SECURITY: CORS_ORIGINS must be explicitly set to prevent unauthorized access
-if not settings.cors_origins:
-    logger.error(
-        "CRITICAL: CORS_ORIGINS environment variable is not set. "
-        "This is a security requirement. Set comma-separated allowed origins."
-    )
-    raise ValueError(
-        "CORS_ORIGINS must be set via environment variable. "
-        "Wildcard (*) is not allowed for security. "
-        "Example: CORS_ORIGINS=http://localhost:3000,https://app.example.com"
-    )
-
-# Parse and validate CORS origins
-allowed_origins = [origin.strip() for origin in settings.cors_origins.split(",")]
-
-# Validate no wildcard in origins
-if "*" in allowed_origins:
-    logger.error(
-        "CRITICAL: Wildcard (*) is not allowed in CORS_ORIGINS. "
-        "Specify explicit origins for security."
-    )
-    raise ValueError(
-        "Wildcard (*) is not allowed in CORS_ORIGINS. "
-        "Specify explicit allowed origins (e.g., http://localhost:3000,https://app.example.com)"
-    )
-
+# Configure CORS — strict: no wildcards, explicit method/header allowlists.
+# See admin-api/app/core/cors.py for the policy (issue #111).
+allowed_origins = configure_cors(app, settings)
 logger.info(f"CORS configured with {len(allowed_origins)} allowed origins")
-
-app.add_middleware(
-    CORSMiddleware,
-    allow_origins=allowed_origins,
-    allow_credentials=True,
-    allow_methods=[
-        "GET",
-        "POST",
-        "PUT",
-        "DELETE",
-        "OPTIONS",
-    ],  # Explicit methods instead of wildcard
-    allow_headers=["Content-Type", "Authorization"],  # Explicit headers instead of wildcard
-)
 
 
 @app.get("/health", tags=["Health"])

--- a/deploy/security.env.template
+++ b/deploy/security.env.template
@@ -37,7 +37,7 @@ SESSION_ABSOLUTE_TIMEOUT_HOURS=12
 API_RATE_LIMIT_PER_MINUTE=60
 API_RATE_LIMIT_PER_HOUR=1000
 API_KEY_ROTATION_DAYS=90
-CORS_ALLOWED_ORIGINS=  # Comma-separated list of allowed origins
+CORS_ORIGINS=  # REQUIRED comma-separated list. Wildcard (*) rejected at startup — see #111.
 
 # Network Security
 ALLOWED_IP_RANGES=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16

--- a/tests/unit/test_admin_api_cors.py
+++ b/tests/unit/test_admin_api_cors.py
@@ -62,13 +62,13 @@ def test_accepts_multiple_valid_origins_trimming_whitespace() -> None:
     assert opts["allow_origins"] == ["http://localhost:3000", "https://app.example.com"]
 
 
-def test_credentials_never_combined_with_wildcard() -> None:
-    """After configure_cors, if credentials are allowed, origins must not be ['*']."""
+def test_credentials_enabled_and_origins_are_never_wildcard() -> None:
+    """Unconditional assertion: credentials on, wildcard off, always together."""
     app = FastAPI()
     configure_cors(app, _settings("http://localhost:3000"))
     opts = _cors_middleware_options(app)
-    if opts.get("allow_credentials"):
-        assert "*" not in opts["allow_origins"]
+    assert opts["allow_credentials"] is True
+    assert "*" not in opts["allow_origins"]
 
 
 def test_methods_are_explicit_allowlist_not_wildcard() -> None:
@@ -87,8 +87,16 @@ def test_headers_are_explicit_allowlist_not_wildcard() -> None:
     assert set(opts["allow_headers"]) == {"Content-Type", "Authorization"}
 
 
-def test_expose_headers_does_not_contain_wildcard() -> None:
+def test_expose_headers_is_not_set() -> None:
+    """expose_headers defaults to [] when unset, never ['*']."""
     app = FastAPI()
     configure_cors(app, _settings("http://localhost:3000"))
     opts = _cors_middleware_options(app)
-    assert "*" not in opts.get("expose_headers", [])
+    assert opts.get("expose_headers", []) == []
+
+
+def test_rejects_whitespace_only_origin() -> None:
+    """A single whitespace entry is equivalent to empty — must fail fast."""
+    app = FastAPI()
+    with pytest.raises(ValueError, match="CORS_ORIGINS"):
+        configure_cors(app, _settings("   "))

--- a/tests/unit/test_admin_api_cors.py
+++ b/tests/unit/test_admin_api_cors.py
@@ -14,7 +14,7 @@ _ADMIN_API_ROOT = _PROJECT_ROOT / "admin-api"
 if str(_ADMIN_API_ROOT) not in sys.path:
     sys.path.insert(0, str(_ADMIN_API_ROOT))
 
-from app.core.cors import configure_cors  # type: ignore  # noqa: E402
+from app.core.cors import configure_cors  # type: ignore
 
 
 def _settings(cors_origins: str) -> SimpleNamespace:
@@ -38,13 +38,13 @@ def test_rejects_empty_cors_origins() -> None:
 
 def test_rejects_exact_wildcard() -> None:
     app = FastAPI()
-    with pytest.raises(ValueError, match="[Ww]ildcard"):
+    with pytest.raises(ValueError, match=r"[Ww]ildcard"):
         configure_cors(app, _settings("*"))
 
 
 def test_rejects_wildcard_in_comma_separated_list() -> None:
     app = FastAPI()
-    with pytest.raises(ValueError, match="[Ww]ildcard"):
+    with pytest.raises(ValueError, match=r"[Ww]ildcard"):
         configure_cors(app, _settings("http://localhost:3000,*"))
 
 

--- a/tests/unit/test_admin_api_cors.py
+++ b/tests/unit/test_admin_api_cors.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-import sys
+import importlib.util
 from pathlib import Path
 from types import SimpleNamespace
 
@@ -10,12 +10,15 @@ import pytest
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 
-_PROJECT_ROOT = Path(__file__).resolve().parents[2]
-_ADMIN_API_ROOT = _PROJECT_ROOT / "admin-api"
-if str(_ADMIN_API_ROOT) not in sys.path:
-    sys.path.insert(0, str(_ADMIN_API_ROOT))
-
-from app.core.cors import configure_cors  # type: ignore
+# Load cors.py by absolute path to avoid the `app` package-name collision
+# between admin-api/app/ and trading-bot/app/ that otherwise breaks in CI
+# (where both are on PYTHONPATH).
+_CORS_PATH = Path(__file__).resolve().parents[2] / "admin-api" / "app" / "core" / "cors.py"
+_spec = importlib.util.spec_from_file_location("_admin_api_cors", _CORS_PATH)
+assert _spec and _spec.loader
+_admin_api_cors = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(_admin_api_cors)
+configure_cors = _admin_api_cors.configure_cors
 
 
 def _settings(cors_origins: str) -> SimpleNamespace:

--- a/tests/unit/test_admin_api_cors.py
+++ b/tests/unit/test_admin_api_cors.py
@@ -1,4 +1,5 @@
 """Tests for admin-api CORS hardening (issue #111)."""
+
 from __future__ import annotations
 
 import sys

--- a/tests/unit/test_admin_api_cors.py
+++ b/tests/unit/test_admin_api_cors.py
@@ -1,0 +1,94 @@
+"""Tests for admin-api CORS hardening (issue #111)."""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+from fastapi import FastAPI
+from fastapi.middleware.cors import CORSMiddleware
+
+_PROJECT_ROOT = Path(__file__).resolve().parents[2]
+_ADMIN_API_ROOT = _PROJECT_ROOT / "admin-api"
+if str(_ADMIN_API_ROOT) not in sys.path:
+    sys.path.insert(0, str(_ADMIN_API_ROOT))
+
+from app.core.cors import configure_cors  # type: ignore  # noqa: E402
+
+
+def _settings(cors_origins: str) -> SimpleNamespace:
+    # The helper only needs `.cors_origins`; a namespace is enough and keeps the
+    # test decoupled from the full Settings model.
+    return SimpleNamespace(cors_origins=cors_origins)
+
+
+def _cors_middleware_options(app: FastAPI) -> dict:
+    for middleware in app.user_middleware:
+        if middleware.cls is CORSMiddleware:
+            return middleware.kwargs
+    raise AssertionError("CORSMiddleware not registered on app")
+
+
+def test_rejects_empty_cors_origins() -> None:
+    app = FastAPI()
+    with pytest.raises(ValueError, match="CORS_ORIGINS"):
+        configure_cors(app, _settings(""))
+
+
+def test_rejects_exact_wildcard() -> None:
+    app = FastAPI()
+    with pytest.raises(ValueError, match="[Ww]ildcard"):
+        configure_cors(app, _settings("*"))
+
+
+def test_rejects_wildcard_in_comma_separated_list() -> None:
+    app = FastAPI()
+    with pytest.raises(ValueError, match="[Ww]ildcard"):
+        configure_cors(app, _settings("http://localhost:3000,*"))
+
+
+def test_accepts_single_valid_origin() -> None:
+    app = FastAPI()
+    configure_cors(app, _settings("http://localhost:3000"))
+    opts = _cors_middleware_options(app)
+    assert opts["allow_origins"] == ["http://localhost:3000"]
+
+
+def test_accepts_multiple_valid_origins_trimming_whitespace() -> None:
+    app = FastAPI()
+    configure_cors(app, _settings(" http://localhost:3000 , https://app.example.com "))
+    opts = _cors_middleware_options(app)
+    assert opts["allow_origins"] == ["http://localhost:3000", "https://app.example.com"]
+
+
+def test_credentials_never_combined_with_wildcard() -> None:
+    """After configure_cors, if credentials are allowed, origins must not be ['*']."""
+    app = FastAPI()
+    configure_cors(app, _settings("http://localhost:3000"))
+    opts = _cors_middleware_options(app)
+    if opts.get("allow_credentials"):
+        assert "*" not in opts["allow_origins"]
+
+
+def test_methods_are_explicit_allowlist_not_wildcard() -> None:
+    app = FastAPI()
+    configure_cors(app, _settings("http://localhost:3000"))
+    opts = _cors_middleware_options(app)
+    assert opts["allow_methods"] != ["*"]
+    assert set(opts["allow_methods"]) == {"GET", "POST", "PUT", "DELETE", "OPTIONS"}
+
+
+def test_headers_are_explicit_allowlist_not_wildcard() -> None:
+    app = FastAPI()
+    configure_cors(app, _settings("http://localhost:3000"))
+    opts = _cors_middleware_options(app)
+    assert opts["allow_headers"] != ["*"]
+    assert set(opts["allow_headers"]) == {"Content-Type", "Authorization"}
+
+
+def test_expose_headers_does_not_contain_wildcard() -> None:
+    app = FastAPI()
+    configure_cors(app, _settings("http://localhost:3000"))
+    opts = _cors_middleware_options(app)
+    assert "*" not in opts.get("expose_headers", [])


### PR DESCRIPTION
## Summary
- `admin_api.py` previously configured `allow_origins=['*']` fallback with `allow_credentials=True`, and `allow_methods/headers/expose_headers=['*']`. Even though browsers reject `*` + credentials, the `*` method/header/expose wildcards plus a mis-set `CORS_ORIGINS=*` constituted a CORS bypass.
- `main.py` already had strict CORS; only `admin_api.py` was vulnerable.
- Extract the policy into `admin-api/app/core/cors.py:configure_cors(app, settings)` and route **both** entrypoints through it so they can never drift again.

## Acceptance criteria (all GREEN)
1. Fail-fast `ValueError` when `CORS_ORIGINS` is empty.
2. Fail-fast `ValueError` when `CORS_ORIGINS` equals `*` or contains `*` in a comma list.
3. `allow_credentials=True` and `allow_origins=['*']` can never coexist (ensured by 1+2).
4. `allow_methods` is the explicit list `[GET, POST, PUT, DELETE, OPTIONS]` — never `['*']`.
5. `allow_headers` is the explicit list `[Content-Type, Authorization]` — never `['*']`.
6. `expose_headers` does not contain `'*'`.
7. Valid comma-separated origins pass through (whitespace trimmed).
8. Both entrypoints (`main.py`, `admin_api.py`) delegate to `configure_cors`, so future changes land in one place.

## Key changes
- **New**: `admin-api/app/core/cors.py` — 56 LOC helper, validated via `Protocol` so tests can pass a `SimpleNamespace` stub.
- **Refactor**: `admin-api/admin_api.py` — drops the 12-line permissive CORS block + unused `CORSMiddleware` import; calls `configure_cors`.
- **Refactor**: `admin-api/main.py` — drops its inline 35-line CORS validator (behavior-preserving) and calls the same helper.
- **New tests**: `tests/unit/test_admin_api_cors.py` — 9 tests covering every acceptance criterion, no external deps.

## TDD history
```
d40f202 test(admin-api): add CORS hardening test suite [RED]
7766f77 feat(admin-api): add shared configure_cors helper [GREEN]
d594c79 refactor(admin-api): route both entrypoints through configure_cors
93d8c63 chore(admin-api): appease ruff (raw regex, drop unused noqa)
```

## Test plan
- [x] 9/9 new CORS unit tests pass
- [x] Smoke-tested both `main.py` and `admin_api.py`: valid origins configure 1/2 origins with explicit methods; empty/wildcard → `ValueError` at import time
- [x] Ruff clean on changed files
- [ ] Full CI green
- [ ] E2E stack boots (CORS_ORIGINS is set in `docker-compose.traefik.yml` with a sensible default, so no breakage expected)

Closes #111

🤖 Generated with [Claude Code](https://claude.com/claude-code)