### PR TITLE
fix(alert-router): align Alert model fields in production code and tests (#179)

### DIFF
--- a/alert-router/app/alert_router.py
+++ b/alert-router/app/alert_router.py
@@ -198,7 +198,7 @@ class AlertRouter:
             alert = Alert.model_validate_json(alert_json)
 
             logger.info(
-                f"Processing alert: {alert.reason} for follower {alert.follower_id} "
+                f"Processing alert: {alert.message} for follower {alert.follower_id} "
                 f"with severity {alert.severity}"
             )
 
@@ -242,7 +242,6 @@ class AlertRouter:
             AlertSeverity.INFO: "ℹ️",
             AlertSeverity.WARNING: "⚠️",
             AlertSeverity.CRITICAL: "🚨",
-            AlertSeverity.ERROR: "❌",
         }
 
         emoji = severity_emoji.get(alert.severity, "📢")
@@ -250,10 +249,10 @@ class AlertRouter:
         message = (
             f"{emoji} *SpreadPilot Alert*\n\n"
             f"*Severity:* {alert.severity.value}\n"
-            f"*Service:* {alert.service}\n"
-            f"*Follower:* {alert.follower_id}\n"
-            f"*Reason:* {alert.reason}\n"
-            f"*Time:* {time.strftime('%Y-%m-%d %H:%M:%S UTC', time.gmtime(alert.timestamp))}"
+            f"*Type:* {alert.type.value}\n"
+            f"*Follower:* {alert.follower_id or 'N/A'}\n"
+            f"*Message:* {alert.message}\n"
+            f"*Time:* {alert.created_at.strftime('%Y-%m-%d %H:%M:%S UTC')}"
         )
 
         # Send to Telegram
@@ -289,17 +288,17 @@ class AlertRouter:
         msg = MIMEMultipart()
         msg["From"] = self.config.email_from
         msg["To"] = self.config.email_to
-        msg["Subject"] = f"SpreadPilot Alert: {alert.severity.value} - {alert.reason[:50]}"
+        msg["Subject"] = f"SpreadPilot Alert: {alert.severity.value} - {alert.message[:50]}"
 
         # Email body
         body = f"""
 SpreadPilot Alert Notification
 
 Severity: {alert.severity.value}
-Service: {alert.service}
-Follower: {alert.follower_id}
-Reason: {alert.reason}
-Time: {time.strftime('%Y-%m-%d %H:%M:%S UTC', time.gmtime(alert.timestamp))}
+Type: {alert.type.value}
+Follower: {alert.follower_id or 'N/A'}
+Message: {alert.message}
+Time: {alert.created_at.strftime('%Y-%m-%d %H:%M:%S UTC')}
 
 This is an automated alert from the SpreadPilot trading system.
         """

--- a/tests/unit/test_alert_router.py
+++ b/tests/unit/test_alert_router.py
@@ -2,13 +2,12 @@
 
 import asyncio
 import json
-import time
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from fakeredis import aioredis as fakeredis
 from httpx import Response
-from spreadpilot_core.models.alert import Alert, AlertSeverity
+from spreadpilot_core.models.alert import Alert, AlertSeverity, AlertType
 
 
 @pytest.fixture
@@ -23,11 +22,11 @@ async def fake_redis():
 def mock_alert():
     """Create a mock alert for testing."""
     return Alert(
+        _id="test_alert_id_123",
         follower_id="test_follower_123",
-        reason="Test alert reason",
         severity=AlertSeverity.CRITICAL,
-        service="test_service",
-        timestamp=time.time(),
+        type=AlertType.GATEWAY_UNREACHABLE,
+        message="Test alert reason",
     )
 
 
@@ -131,7 +130,7 @@ class TestAlertRouter:
         json_data = call_args[1]["json"]
         assert json_data["chat_id"] == "test_chat_id"
         assert "SpreadPilot Alert" in json_data["text"]
-        assert mock_alert.reason in json_data["text"]
+        assert mock_alert.message in json_data["text"]
 
     @pytest.mark.asyncio
     async def test_email_notification_with_retry(self, alert_router, mock_alert):
@@ -230,15 +229,27 @@ class TestAlertRouter:
     @pytest.mark.asyncio
     async def test_consumer_group_creation(self, alert_router, fake_redis):
         """Test that consumer group is created if it doesn't exist."""
-        alert_router.redis_client = fake_redis
 
-        # Mock other dependencies
-        alert_router.mongo_client = MagicMock()
-        alert_router.mongo_db = MagicMock()
-        alert_router.httpx_client = AsyncMock()
+        # Patch the connection initializers so start() keeps our pre-configured
+        # fake_redis / mocked mongo / mocked httpx instead of replacing them with
+        # real clients that would attempt network I/O.
+        async def _fake_init_redis():
+            alert_router.redis_client = fake_redis
 
-        # Start router (which should create consumer group)
-        with patch.object(alert_router, "_process_alerts", new_callable=AsyncMock):
+        async def _fake_init_mongo():
+            alert_router.mongo_client = MagicMock()
+            alert_router.mongo_db = MagicMock()
+
+        async def _fake_init_httpx():
+            alert_router.httpx_client = AsyncMock()
+
+        with (
+            patch.object(alert_router, "_init_redis", side_effect=_fake_init_redis),
+            patch.object(alert_router, "_init_mongo", side_effect=_fake_init_mongo),
+            patch.object(alert_router, "_init_httpx", side_effect=_fake_init_httpx),
+            patch.object(alert_router, "_load_vault_secrets", new_callable=AsyncMock),
+            patch.object(alert_router, "_process_alerts", new_callable=AsyncMock),
+        ):
             await alert_router.start()
 
         # Verify consumer group exists

--- a/tests/unit/test_alert_router_complete.py
+++ b/tests/unit/test_alert_router_complete.py
@@ -2,15 +2,13 @@
 
 import asyncio
 import json
-import time
 from unittest.mock import AsyncMock, patch
 
 import fakeredis.aioredis
 import httpx
 import pytest
 from alert_router.app.alert_router import AlertRouter, AlertRouterConfig
-from pytest_httpx import HTTPXMock
-from spreadpilot_core.models.alert import Alert, AlertSeverity
+from spreadpilot_core.models.alert import Alert, AlertSeverity, AlertType
 
 
 @pytest.fixture
@@ -50,11 +48,11 @@ async def mock_router(alert_config, fake_redis):
 def test_alert():
     """Create a test alert."""
     return Alert(
+        _id="test_alert_id_456",
         follower_id="test_follower",
-        reason="Test alert reason",
         severity=AlertSeverity.CRITICAL,
-        service="test_service",
-        timestamp=time.time(),
+        type=AlertType.GATEWAY_UNREACHABLE,
+        message="Test alert reason",
     )
 
 
@@ -62,102 +60,100 @@ class TestAlertRouter:
     """Test alert router functionality."""
 
     @pytest.mark.asyncio
-    async def test_telegram_message_sent(self, mock_router, test_alert):
+    async def test_telegram_message_sent(self, mock_router, test_alert, httpx_mock):
         """Test that Telegram messages are sent correctly."""
-        with HTTPXMock() as httpx_mock:
-            # Mock Telegram API response
-            httpx_mock.add_response(
-                method="POST",
-                url=f"https://api.telegram.org/bot{mock_router.config.telegram_bot_token}/sendMessage",
-                json={"ok": True, "result": {"message_id": 123}},
-                status_code=200,
-            )
+        # Mock Telegram API response
+        httpx_mock.add_response(
+            method="POST",
+            url=f"https://api.telegram.org/bot{mock_router.config.telegram_bot_token}/sendMessage",
+            json={"ok": True, "result": {"message_id": 123}},
+            status_code=200,
+        )
 
-            # Create real httpx client for this test
-            mock_router.httpx_client = httpx.AsyncClient()
+        # Create real httpx client for this test
+        mock_router.httpx_client = httpx.AsyncClient()
 
-            try:
-                # Send Telegram alert
-                await mock_router._send_telegram_with_retry(test_alert)
+        try:
+            # Send Telegram alert
+            await mock_router._send_telegram_with_retry(test_alert)
 
-                # Verify the request was made
-                requests = httpx_mock.get_requests()
-                assert len(requests) == 1
+            # Verify the request was made
+            requests = httpx_mock.get_requests()
+            assert len(requests) == 1
 
-                request = requests[0]
-                assert request.method == "POST"
-                assert f"bot{mock_router.config.telegram_bot_token}" in str(request.url)
+            request = requests[0]
+            assert request.method == "POST"
+            assert f"bot{mock_router.config.telegram_bot_token}" in str(request.url)
 
-                # Check request payload
-                payload = json.loads(request.content)
-                assert payload["chat_id"] == mock_router.config.telegram_chat_id
-                assert "SpreadPilot Alert" in payload["text"]
-                assert test_alert.reason in payload["text"]
-                assert test_alert.severity.value in payload["text"]
+            # Check request payload
+            payload = json.loads(request.content)
+            assert payload["chat_id"] == mock_router.config.telegram_chat_id
+            assert "SpreadPilot Alert" in payload["text"]
+            assert test_alert.message in payload["text"]
+            assert test_alert.severity.value in payload["text"]
 
-            finally:
-                await mock_router.httpx_client.aclose()
+        finally:
+            await mock_router.httpx_client.aclose()
 
     @pytest.mark.asyncio
-    async def test_telegram_retry_on_failure(self, mock_router, test_alert):
+    async def test_telegram_retry_on_failure(self, mock_router, test_alert, httpx_mock):
         """Test that Telegram sending retries on failure."""
-        with HTTPXMock() as httpx_mock:
-            # Mock failed responses (first 2 fail, 3rd succeeds)
-            httpx_mock.add_response(
-                method="POST",
-                url=f"https://api.telegram.org/bot{mock_router.config.telegram_bot_token}/sendMessage",
-                status_code=500,
-            )
-            httpx_mock.add_response(
-                method="POST",
-                url=f"https://api.telegram.org/bot{mock_router.config.telegram_bot_token}/sendMessage",
-                status_code=500,
-            )
-            httpx_mock.add_response(
-                method="POST",
-                url=f"https://api.telegram.org/bot{mock_router.config.telegram_bot_token}/sendMessage",
-                json={"ok": True, "result": {"message_id": 123}},
-                status_code=200,
-            )
+        # Mock failed responses (first 2 fail, 3rd succeeds)
+        httpx_mock.add_response(
+            method="POST",
+            url=f"https://api.telegram.org/bot{mock_router.config.telegram_bot_token}/sendMessage",
+            status_code=500,
+        )
+        httpx_mock.add_response(
+            method="POST",
+            url=f"https://api.telegram.org/bot{mock_router.config.telegram_bot_token}/sendMessage",
+            status_code=500,
+        )
+        httpx_mock.add_response(
+            method="POST",
+            url=f"https://api.telegram.org/bot{mock_router.config.telegram_bot_token}/sendMessage",
+            json={"ok": True, "result": {"message_id": 123}},
+            status_code=200,
+        )
 
-            mock_router.httpx_client = httpx.AsyncClient()
+        mock_router.httpx_client = httpx.AsyncClient()
 
-            try:
-                # Should succeed on 3rd attempt
-                await mock_router._send_telegram_with_retry(test_alert)
+        try:
+            # Should succeed on 3rd attempt
+            await mock_router._send_telegram_with_retry(test_alert)
 
-                # Verify 3 requests were made
-                requests = httpx_mock.get_requests()
-                assert len(requests) == 3
+            # Verify 3 requests were made
+            requests = httpx_mock.get_requests()
+            assert len(requests) == 3
 
-            finally:
-                await mock_router.httpx_client.aclose()
+        finally:
+            await mock_router.httpx_client.aclose()
 
     @pytest.mark.asyncio
-    async def test_telegram_max_retries_exceeded(self, mock_router, test_alert):
+    async def test_telegram_max_retries_exceeded(self, mock_router, test_alert, httpx_mock):
         """Test that Telegram sending fails after max retries."""
-        with HTTPXMock() as httpx_mock:
-            # Mock all responses as failures
-            for _ in range(5):  # More than max_tries=3
-                httpx_mock.add_response(
-                    method="POST",
-                    url=f"https://api.telegram.org/bot{mock_router.config.telegram_bot_token}/sendMessage",
-                    status_code=500,
-                )
+        # Mock exactly max_tries=3 failures. pytest_httpx asserts all mocked
+        # responses are consumed in teardown, so over-registering would error.
+        for _ in range(3):
+            httpx_mock.add_response(
+                method="POST",
+                url=f"https://api.telegram.org/bot{mock_router.config.telegram_bot_token}/sendMessage",
+                status_code=500,
+            )
 
-            mock_router.httpx_client = httpx.AsyncClient()
+        mock_router.httpx_client = httpx.AsyncClient()
 
-            try:
-                # Should raise exception after 3 attempts
-                with pytest.raises(httpx.HTTPStatusError):
-                    await mock_router._send_telegram_with_retry(test_alert)
+        try:
+            # Should raise exception after 3 attempts
+            with pytest.raises(httpx.HTTPStatusError):
+                await mock_router._send_telegram_with_retry(test_alert)
 
-                # Verify exactly 3 attempts were made
-                requests = httpx_mock.get_requests()
-                assert len(requests) == 3
+            # Verify exactly 3 attempts were made
+            requests = httpx_mock.get_requests()
+            assert len(requests) == 3
 
-            finally:
-                await mock_router.httpx_client.aclose()
+        finally:
+            await mock_router.httpx_client.aclose()
 
     @pytest.mark.asyncio
     async def test_email_sending(self, mock_router, test_alert):
@@ -181,7 +177,7 @@ class TestAlertRouter:
             # Check message content
             sent_message = smtp_instance.send_message.call_args[0][0]
             assert sent_message["Subject"].startswith("SpreadPilot Alert: CRITICAL")
-            assert test_alert.reason in str(sent_message)
+            assert test_alert.message in str(sent_message)
 
     @pytest.mark.asyncio
     async def test_email_retry_on_failure(self, mock_router, test_alert):
@@ -255,53 +251,16 @@ class TestAlertRouter:
         assert inserted_doc["status"] == "completed"
 
     @pytest.mark.asyncio
-    async def test_alert_severity_emojis(self, mock_router):
+    async def test_alert_severity_emojis(self, mock_router, httpx_mock):
         """Test that different alert severities use correct emojis."""
         test_cases = [
             (AlertSeverity.INFO, "ℹ️"),
             (AlertSeverity.WARNING, "⚠️"),
             (AlertSeverity.CRITICAL, "🚨"),
-            (AlertSeverity.ERROR, "❌"),
         ]
 
-        with HTTPXMock() as httpx_mock:
-            # Mock successful responses for all severities
-            for _ in test_cases:
-                httpx_mock.add_response(
-                    method="POST",
-                    url=f"https://api.telegram.org/bot{mock_router.config.telegram_bot_token}/sendMessage",
-                    json={"ok": True, "result": {"message_id": 123}},
-                    status_code=200,
-                )
-
-            mock_router.httpx_client = httpx.AsyncClient()
-
-            try:
-                for severity, expected_emoji in test_cases:
-                    alert = Alert(
-                        follower_id="test",
-                        reason="Test",
-                        severity=severity,
-                        service="test",
-                        timestamp=time.time(),
-                    )
-
-                    await mock_router._send_telegram_with_retry(alert)
-
-                # Check that correct emojis were used
-                requests = httpx_mock.get_requests()
-                for i, (severity, expected_emoji) in enumerate(test_cases):
-                    payload = json.loads(requests[i].content)
-                    assert expected_emoji in payload["text"]
-
-            finally:
-                await mock_router.httpx_client.aclose()
-
-    @pytest.mark.asyncio
-    async def test_partial_delivery_failure(self, mock_router, test_alert):
-        """Test handling when one delivery method fails but other succeeds."""
-        # Mock Telegram success, email failure
-        with HTTPXMock() as httpx_mock:
+        # Mock successful responses for all severities
+        for _ in test_cases:
             httpx_mock.add_response(
                 method="POST",
                 url=f"https://api.telegram.org/bot{mock_router.config.telegram_bot_token}/sendMessage",
@@ -309,28 +268,62 @@ class TestAlertRouter:
                 status_code=200,
             )
 
-            mock_router.httpx_client = httpx.AsyncClient()
+        mock_router.httpx_client = httpx.AsyncClient()
 
-            with patch("alert_router.app.alert_router.aiosmtplib.SMTP") as mock_smtp:
-                smtp_instance = AsyncMock()
-                mock_smtp.return_value.__aenter__.return_value = smtp_instance
-                smtp_instance.send_message.side_effect = Exception("SMTP Failed")
+        try:
+            for severity, expected_emoji in test_cases:
+                alert = Alert(
+                    _id=f"test_{severity.value.lower()}",
+                    follower_id="test",
+                    severity=severity,
+                    type=AlertType.GATEWAY_UNREACHABLE,
+                    message="Test",
+                )
 
-                mock_router._log_alert_to_mongo = AsyncMock()
+                await mock_router._send_telegram_with_retry(alert)
 
-                try:
-                    # Process alert data
-                    alert_data = {"data": test_alert.model_dump_json()}
-                    await mock_router._process_single_alert("test_id", alert_data)
+            # Check that correct emojis were used
+            requests = httpx_mock.get_requests()
+            for i, (severity, expected_emoji) in enumerate(test_cases):
+                payload = json.loads(requests[i].content)
+                assert expected_emoji in payload["text"]
 
-                    # Verify logging shows partial success
-                    log_call = mock_router._log_alert_to_mongo.call_args
-                    assert log_call[1]["success"] is False  # Overall failed due to email
-                    assert log_call[1]["telegram_sent"] is True
-                    assert log_call[1]["email_sent"] is False
+        finally:
+            await mock_router.httpx_client.aclose()
 
-                finally:
-                    await mock_router.httpx_client.aclose()
+    @pytest.mark.asyncio
+    async def test_partial_delivery_failure(self, mock_router, test_alert, httpx_mock):
+        """Test handling when one delivery method fails but other succeeds."""
+        # Mock Telegram success, email failure
+        httpx_mock.add_response(
+            method="POST",
+            url=f"https://api.telegram.org/bot{mock_router.config.telegram_bot_token}/sendMessage",
+            json={"ok": True, "result": {"message_id": 123}},
+            status_code=200,
+        )
+
+        mock_router.httpx_client = httpx.AsyncClient()
+
+        with patch("alert_router.app.alert_router.aiosmtplib.SMTP") as mock_smtp:
+            smtp_instance = AsyncMock()
+            mock_smtp.return_value.__aenter__.return_value = smtp_instance
+            smtp_instance.send_message.side_effect = Exception("SMTP Failed")
+
+            mock_router._log_alert_to_mongo = AsyncMock()
+
+            try:
+                # Process alert data
+                alert_data = {"data": test_alert.model_dump_json()}
+                await mock_router._process_single_alert("test_id", alert_data)
+
+                # Verify logging shows partial success
+                log_call = mock_router._log_alert_to_mongo.call_args
+                assert log_call[1]["success"] is False  # Overall failed due to email
+                assert log_call[1]["telegram_sent"] is True
+                assert log_call[1]["email_sent"] is False
+
+            finally:
+                await mock_router.httpx_client.aclose()
 
 
 class TestAlertRouterIntegration:
@@ -363,11 +356,11 @@ class TestAlertRouterIntegration:
 
         # Add test alert to stream
         test_alert = Alert(
+            _id="integration_test_alert",
             follower_id="integration_test",
-            reason="Integration test alert",
             severity=AlertSeverity.WARNING,
-            service="test",
-            timestamp=time.time(),
+            type=AlertType.GATEWAY_UNREACHABLE,
+            message="Integration test alert",
         )
 
         alert_data = {"data": test_alert.model_dump_json()}


### PR DESCRIPTION
## Summary
Fixes #179. Resolves the 7 failing tests flagged as "Alert model validation drift" plus a second layer of test bugs (`HTTPXMock` context-manager API change, real-Motor client in `start()`) that were hidden behind the cascade.

**Key discovery during investigation**: `alert-router/Dockerfile:35` launches `uvicorn app.alert_router:app`, making `alert_router.py` the *production* container entrypoint — not dead code, as might initially appear. That file was referencing model fields that no longer exist (`alert.reason`, `alert.service`, `alert.timestamp`, `AlertSeverity.ERROR`), so the production service was effectively broken any time it tried to deserialise an Alert, not only the tests.

## Field mapping applied
| Legacy field (used by prod code) | Current model | Note |
|---|---|---|
| `alert.reason` | `alert.message` | rename |
| `alert.timestamp` (unix float) | `alert.created_at` (datetime) | rename + type change |
| `alert.service` | *(removed from model)* | dropped from Telegram/email templates; was only used for UI formatting |
| `AlertSeverity.ERROR` | *(removed from enum)* | only INFO/WARNING/CRITICAL remain |
| `id` / `_id` (required) | now required by model | added to fixtures |
| `type: AlertType` (required) | now required by model | added to fixtures + production templates |

## Changes
### Production (`alert-router/app/alert_router.py`)
- `_process_single_alert`: log uses `alert.message` instead of `alert.reason`.
- `_send_telegram_with_retry`: template uses `message` / `type.value` / `created_at.strftime(...)`; removes `service` reference; drops `AlertSeverity.ERROR` from the emoji map.
- `_send_email_with_retry`: subject uses `alert.message[:50]`; body uses `message` / `type.value` / `created_at.strftime(...)`; removes `service`.

### Tests (`tests/unit/test_alert_router.py`, `tests/unit/test_alert_router_complete.py`)
- Fixture factories construct `Alert(_id=..., follower_id=..., severity=..., type=AlertType.GATEWAY_UNREACHABLE, message=...)`.
- Assertions reading `alert.reason` → `alert.message`.
- `test_alert_severity_emojis` drops the `AlertSeverity.ERROR` row.
- Five `with HTTPXMock() as httpx_mock:` blocks refactored to use the injected `httpx_mock` fixture (newer `pytest_httpx` no longer supports the class-based context manager).
- `test_telegram_max_retries_exceeded`: register exactly 3 responses (not 5) because the plugin asserts all mocked responses are consumed at teardown.
- `test_consumer_group_creation`: patch `_init_redis` / `_init_mongo` / `_init_httpx` / `_load_vault_secrets` so `start()` does not replace the mocked mongo_db with a real Motor client that would attempt a network connection.

## Test results
**Before**: 15 tests in these two files erroring or failing.
**After**: **17 passing, 1 failing.**

The 1 remaining failure is `test_health_endpoint` — a `TestClient(app)` that triggers real Motor connections during FastAPI startup. That test was not in the original #179 scope ("Alert model drift, 7 failures"); it was invisible behind the collection cascade before. I will file a follow-up issue for it.

## Acceptance criteria (all GREEN except as noted)
- [x] Alert fixtures construct valid instances against current model
- [x] Production `alert_router.py` uses current field names
- [x] `severity_emoji` map aligned to 3-value enum
- [x] `created_at.strftime(...)` replaces `time.gmtime(alert.timestamp)`
- [x] `test_alert_severity_emojis` asserts on 3 values, no `ERROR`
- [x] 7 originally failing tests from #179 now pass
- [x] No regression in other tests
- [ ] `test_health_endpoint` (out of scope, see follow-up)

## Commits (TDD-compatible: production change + test fix each in its own commit)
- `a673649` fix(alert-router): use current Alert model fields (#179)
- `bdc4ff0` test(alert-router): align fixtures to current Alert model + pytest_httpx API (#179)

Fixes #179

🤖 Generated with [Claude Code](https://claude.com/claude-code)