### PR TITLE
refactor(core): migrate str+Enum classes to StrEnum (#187)

### DIFF
--- a/admin-api/app/api/v1/endpoints/manual_operations.py
+++ b/admin-api/app/api/v1/endpoints/manual_operations.py
@@ -44,14 +44,18 @@ if not MANUAL_OPERATION_PIN:
 if len(MANUAL_OPERATION_PIN) < 6:
     logger.error(
         "CRITICAL: MANUAL_OPERATION_PIN is too short (minimum 6 characters required). "
-        "Current length: %d", len(MANUAL_OPERATION_PIN)
+        "Current length: %d",
+        len(MANUAL_OPERATION_PIN),
     )
     raise ValueError(
         f"MANUAL_OPERATION_PIN must be at least 6 characters long. "
         f"Current length: {len(MANUAL_OPERATION_PIN)}"
     )
 
-logger.info("Manual operations PIN validated successfully (length: %d characters)", len(MANUAL_OPERATION_PIN))
+logger.info(
+    "Manual operations PIN validated successfully (length: %d characters)",
+    len(MANUAL_OPERATION_PIN),
+)
 
 
 class ManualCloseRequest(BaseModel):

--- a/admin-api/main.py
+++ b/admin-api/main.py
@@ -135,7 +135,13 @@ app.add_middleware(
     CORSMiddleware,
     allow_origins=allowed_origins,
     allow_credentials=True,
-    allow_methods=["GET", "POST", "PUT", "DELETE", "OPTIONS"],  # Explicit methods instead of wildcard
+    allow_methods=[
+        "GET",
+        "POST",
+        "PUT",
+        "DELETE",
+        "OPTIONS",
+    ],  # Explicit methods instead of wildcard
     allow_headers=["Content-Type", "Authorization"],  # Explicit headers instead of wildcard
 )
 

--- a/paper-gateway/app/models.py
+++ b/paper-gateway/app/models.py
@@ -1,27 +1,27 @@
 """Data models for paper trading gateway."""
 
 from datetime import datetime
-from enum import Enum
+from enum import StrEnum
 from typing import Optional
 
 from pydantic import BaseModel, Field
 
 
-class OrderAction(str, Enum):
+class OrderAction(StrEnum):
     """Order action."""
 
     BUY = "BUY"
     SELL = "SELL"
 
 
-class OrderType(str, Enum):
+class OrderType(StrEnum):
     """Order type."""
 
     MARKET = "MKT"
     LIMIT = "LMT"
 
 
-class OrderStatus(str, Enum):
+class OrderStatus(StrEnum):
     """Order status."""
 
     PENDING = "PENDING"
@@ -32,14 +32,14 @@ class OrderStatus(str, Enum):
     REJECTED = "REJECTED"
 
 
-class AssetType(str, Enum):
+class AssetType(StrEnum):
     """Asset type."""
 
     STOCK = "STOCK"
     OPTION = "OPTION"
 
 
-class OptionType(str, Enum):
+class OptionType(StrEnum):
     """Option type."""
 
     CALL = "CALL"

--- a/spreadpilot-core/spreadpilot_core/ibkr/client.py
+++ b/spreadpilot-core/spreadpilot_core/ibkr/client.py
@@ -3,7 +3,7 @@
 import asyncio
 import datetime
 import time
-from enum import Enum
+from enum import StrEnum
 from functools import lru_cache
 from typing import Any
 
@@ -49,14 +49,14 @@ def _create_stock_contract_cached(
     return Stock(symbol=symbol, exchange=exchange, currency=currency)
 
 
-class OrderSide(str, Enum):
+class OrderSide(StrEnum):
     """Order side enum."""
 
     LONG = "LONG"
     SHORT = "SHORT"
 
 
-class OrderStatus(str, Enum):
+class OrderStatus(StrEnum):
     """Order status enum."""
 
     FILLED = "FILLED"
@@ -67,7 +67,7 @@ class OrderStatus(str, Enum):
     PENDING = "PENDING"
 
 
-class AssignmentState(str, Enum):
+class AssignmentState(StrEnum):
     """Assignment state enum."""
 
     NONE = "NONE"

--- a/spreadpilot-core/spreadpilot_core/ibkr/gateway_manager.py
+++ b/spreadpilot-core/spreadpilot_core/ibkr/gateway_manager.py
@@ -5,7 +5,7 @@ import random
 import time
 from dataclasses import dataclass
 from datetime import datetime
-from enum import Enum
+from enum import StrEnum
 
 import backoff
 import docker
@@ -28,7 +28,7 @@ async def get_mongo_db():
 logger = get_logger(__name__)
 
 
-class GatewayStatus(str, Enum):
+class GatewayStatus(StrEnum):
     """Gateway container status."""
 
     STARTING = "STARTING"

--- a/spreadpilot-core/spreadpilot_core/models/alert.py
+++ b/spreadpilot-core/spreadpilot_core/models/alert.py
@@ -1,7 +1,7 @@
 """Alert model for SpreadPilot."""
 
 from datetime import datetime
-from enum import Enum
+from enum import StrEnum
 from typing import Annotated, Any  # Added Annotated
 
 from bson import ObjectId  # Added ObjectId
@@ -20,7 +20,7 @@ def validate_objectid_to_str(v: Any) -> str:
     raise TypeError("ObjectId or str required")
 
 
-class AlertSeverity(str, Enum):
+class AlertSeverity(StrEnum):
     """Alert severity enum."""
 
     INFO = "INFO"
@@ -28,7 +28,7 @@ class AlertSeverity(str, Enum):
     CRITICAL = "CRITICAL"
 
 
-class AlertType(str, Enum):
+class AlertType(StrEnum):
     """Alert type enum."""
 
     COMPONENT_DOWN = "COMPONENT_DOWN"

--- a/spreadpilot-core/spreadpilot_core/models/follower.py
+++ b/spreadpilot-core/spreadpilot_core/models/follower.py
@@ -1,7 +1,7 @@
 """Follower model for SpreadPilot."""
 
 from datetime import datetime
-from enum import Enum
+from enum import StrEnum
 from typing import Annotated, Any  # Added Annotated
 
 from bson import ObjectId  # Added ObjectId
@@ -9,7 +9,7 @@ from pydantic import BaseModel, EmailStr, Field, validator
 from pydantic.functional_validators import BeforeValidator  # Added BeforeValidator
 
 
-class FollowerState(str, Enum):
+class FollowerState(StrEnum):
     """Follower state enum."""
 
     ACTIVE = "ACTIVE"

--- a/spreadpilot-core/spreadpilot_core/models/pnl.py
+++ b/spreadpilot-core/spreadpilot_core/models/pnl.py
@@ -2,7 +2,7 @@
 
 import uuid
 from datetime import datetime
-from enum import Enum
+from enum import StrEnum
 
 from sqlalchemy import Boolean, Column, Date, DateTime, Index, Integer, Numeric, String
 from sqlalchemy.dialects.postgresql import UUID
@@ -11,14 +11,14 @@ from sqlalchemy.ext.declarative import declarative_base
 Base = declarative_base()
 
 
-class TradeType(str, Enum):
+class TradeType(StrEnum):
     """Trade type enumeration."""
 
     BUY = "BUY"
     SELL = "SELL"
 
 
-class QuoteType(str, Enum):
+class QuoteType(StrEnum):
     """Quote type enumeration."""
 
     BID = "BID"

--- a/spreadpilot-core/spreadpilot_core/models/position.py
+++ b/spreadpilot-core/spreadpilot_core/models/position.py
@@ -1,7 +1,7 @@
 """Position model for SpreadPilot."""
 
 from datetime import datetime
-from enum import Enum
+from enum import StrEnum
 from typing import Annotated, Any  # Added Any, Annotated
 
 from bson import ObjectId  # Added ObjectId
@@ -20,7 +20,7 @@ def validate_objectid_to_str(v: Any) -> str:
     raise TypeError("ObjectId or str required")
 
 
-class AssignmentState(str, Enum):
+class AssignmentState(StrEnum):
     """Assignment state enum."""
 
     NONE = "NONE"

--- a/spreadpilot-core/spreadpilot_core/models/trade.py
+++ b/spreadpilot-core/spreadpilot_core/models/trade.py
@@ -1,7 +1,7 @@
 """Trade model for SpreadPilot."""
 
 from datetime import datetime
-from enum import Enum
+from enum import StrEnum
 from typing import Annotated, Any  # Added Any, Annotated
 
 from bson import ObjectId  # Added ObjectId
@@ -20,14 +20,14 @@ def validate_objectid_to_str(v: Any) -> str:
     raise TypeError("ObjectId or str required")
 
 
-class TradeSide(str, Enum):
+class TradeSide(StrEnum):
     """Trade side enum."""
 
     LONG = "LONG"
     SHORT = "SHORT"
 
 
-class TradeStatus(str, Enum):
+class TradeStatus(StrEnum):
     """Trade status enum."""
 
     FILLED = "FILLED"

--- a/spreadpilot-core/spreadpilot_core/simulation.py
+++ b/spreadpilot-core/spreadpilot_core/simulation.py
@@ -4,12 +4,12 @@ Replays historical market data with configurable speed for strategy validation.
 """
 
 import time
-from datetime import datetime, timedelta
-from enum import Enum
+from datetime import datetime
+from enum import StrEnum
 from typing import Any, Callable, Dict, List, Optional
 
 
-class SimulationMode(str, Enum):
+class SimulationMode(StrEnum):
     """Simulation modes."""
 
     BACKTEST = "backtest"  # Full historical replay

--- a/spreadpilot-core/spreadpilot_core/test_data_generator.py
+++ b/spreadpilot-core/spreadpilot_core/test_data_generator.py
@@ -6,11 +6,11 @@ Generates realistic market data, trade scenarios, and edge cases for testing.
 import json
 import random
 from datetime import datetime, timedelta
-from enum import Enum
+from enum import StrEnum
 from typing import Any, Dict, List, Optional
 
 
-class ScenarioType(str, Enum):
+class ScenarioType(StrEnum):
     """Test scenario types."""
 
     WINNING_TRADE = "winning_trade"

--- a/spreadpilot-core/spreadpilot_core/utils/email.py
+++ b/spreadpilot-core/spreadpilot_core/utils/email.py
@@ -3,7 +3,6 @@
 import asyncio
 import datetime
 import os
-import smtplib
 import urllib.parse
 from email.mime.application import MIMEApplication
 from email.mime.multipart import MIMEMultipart

--- a/spreadpilot-core/spreadpilot_core/utils/secret_manager.py
+++ b/spreadpilot-core/spreadpilot_core/utils/secret_manager.py
@@ -6,7 +6,7 @@ services, with automatic fallback to environment variables for backward compatib
 """
 
 import os
-from enum import Enum
+from enum import StrEnum
 from functools import lru_cache
 from typing import Any, Optional
 
@@ -18,7 +18,7 @@ from .vault import VaultClient, get_vault_client
 logger = get_logger(__name__)
 
 
-class SecretType(str, Enum):
+class SecretType(StrEnum):
     """Enumeration of secret types in SpreadPilot."""
 
     # Authentication & Security

--- a/trading-bot/app/service/base.py
+++ b/trading-bot/app/service/base.py
@@ -3,7 +3,7 @@
 import asyncio
 import datetime
 import time
-from enum import Enum
+from enum import StrEnum
 
 # Removed firebase_admin imports
 from motor.motor_asyncio import AsyncIOMotorDatabase  # Added Motor import
@@ -34,7 +34,7 @@ from .vertical_spreads_strategy_handler import VerticalSpreadsStrategyHandler
 logger = get_logger(__name__)
 
 
-class ServiceStatus(str, Enum):
+class ServiceStatus(StrEnum):
     """Service status enum."""
 
     STARTING = "STARTING"

--- a/trading-bot/app/service/time_value_monitor.py
+++ b/trading-bot/app/service/time_value_monitor.py
@@ -6,7 +6,7 @@ Monitors open positions and automatically closes them when time value falls belo
 import asyncio
 import json
 import time
-from enum import Enum
+from enum import StrEnum
 from typing import Any
 
 import ib_insync
@@ -20,7 +20,7 @@ from spreadpilot_core.models.alert import Alert, AlertSeverity
 logger = get_logger(__name__)
 
 
-class TimeValueStatus(str, Enum):
+class TimeValueStatus(StrEnum):
     """Time value status enum."""
 
     SAFE = "SAFE"  # TV > $1.00

--- a/trading-bot/tests/unit/test_time_value_monitor_isolated.py
+++ b/trading-bot/tests/unit/test_time_value_monitor_isolated.py
@@ -1,13 +1,13 @@
 """Isolated unit tests for time value monitor."""
 
 import asyncio
-from enum import Enum
+from enum import StrEnum
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
 
-class RiskStatus(str, Enum):
+class RiskStatus(StrEnum):
     """Risk status levels for time value monitoring."""
 
     SAFE = "SAFE"


### PR DESCRIPTION
## Summary
Closes #187. Replaces every \`class Foo(str, Enum)\` with \`class Foo(StrEnum)\`. **Zero ruff errors** across the repo after the migration — unblocks the \`Python Linting (Ruff & Black)\` CI gate that was red on all pending PRs (#176, #178, #188).

## Scope
14 files, 23 enum classes migrated. Plus collateral F401 cleanup for \`enum.Enum\` imports that became unused and one stale \`smtplib\` import.

## Mechanics
Applied via \`ruff check --select UP042 --fix --unsafe-fixes .\` then \`ruff check --select F401 --fix .\` then \`black .\`. All mechanical.

## Behavioural note
\`StrEnum\` changes \`__str__\` to return the value directly (\`"INFO"\`) instead of \`"AlertSeverity.INFO"\`. I grepped the entire codebase for tests and production code that relied on the legacy repr format:
- No tests assert against \`"ClassName.MEMBER"\` strings.
- No f-strings or log lines rendered enum members without \`.value\`.
- Pydantic serialization uses \`.value\` internally — unaffected.

\`str(Severity.INFO) == "INFO"\`, \`Severity.INFO == "INFO"\`, \`Severity.INFO.value == "INFO"\` all hold. Verified with a live Python sanity check.

## Test plan
- [x] \`ruff check .\` → All checks passed
- [x] Import sanity: every migrated module imports without error
- [x] Equality semantics: \`AlertSeverity.INFO == 'INFO'\` holds (isinstance str)
- [ ] Full test suite (CI) — many unrelated failures pre-exist (#179–#186); this PR is not expected to introduce new ones

## Files
\`\`\`
paper-gateway/app/models.py
spreadpilot-core/spreadpilot_core/ibkr/client.py
spreadpilot-core/spreadpilot_core/ibkr/gateway_manager.py
spreadpilot-core/spreadpilot_core/models/alert.py
spreadpilot-core/spreadpilot_core/models/follower.py
spreadpilot-core/spreadpilot_core/models/pnl.py
spreadpilot-core/spreadpilot_core/models/position.py
spreadpilot-core/spreadpilot_core/models/trade.py
spreadpilot-core/spreadpilot_core/simulation.py
spreadpilot-core/spreadpilot_core/test_data_generator.py
spreadpilot-core/spreadpilot_core/utils/email.py         (F401 cleanup)
spreadpilot-core/spreadpilot_core/utils/secret_manager.py
trading-bot/app/service/base.py
trading-bot/app/service/time_value_monitor.py
trading-bot/tests/unit/test_time_value_monitor_isolated.py
\`\`\`

Closes #187

🤖 Generated with [Claude Code](https://claude.com/claude-code)