### PR TITLE
fix: align Alert producers with current model fields (#190)

### DIFF
--- a/spreadpilot-core/spreadpilot_core/ibkr/gateway_manager.py
+++ b/spreadpilot-core/spreadpilot_core/ibkr/gateway_manager.py
@@ -3,6 +3,7 @@
 import asyncio
 import random
 import time
+import uuid
 from dataclasses import dataclass
 from datetime import datetime
 from enum import StrEnum
@@ -12,7 +13,7 @@ import docker
 from ib_insync import IB
 
 from ..logging import get_logger
-from ..models.alert import Alert, AlertSeverity
+from ..models.alert import Alert, AlertSeverity, AlertType
 from ..models.follower import Follower, FollowerState
 from ..utils.vault import get_vault_client
 
@@ -120,7 +121,7 @@ class GatewayManager:
             if not secret_ref:
                 await self._publish_alert(
                     follower_id=follower.id,
-                    reason=f"No vault_secret_ref configured for follower {follower.id}",
+                    message=f"No vault_secret_ref configured for follower {follower.id}",
                     severity=AlertSeverity.CRITICAL,
                 )
                 return None
@@ -134,7 +135,7 @@ class GatewayManager:
                 logger.warning(f"No IBKR credentials found in Vault for secret: {secret_ref}")
                 await self._publish_alert(
                     follower_id=follower.id,
-                    reason=f"No IBKR credentials found in Vault for secret: {secret_ref}",
+                    message=f"No IBKR credentials found in Vault for secret: {secret_ref}",
                     severity=AlertSeverity.CRITICAL,
                 )
                 return None
@@ -278,7 +279,7 @@ class GatewayManager:
                 if not ibkr_username or not ibkr_password:
                     await self._publish_alert(
                         follower_id=follower.id,
-                        reason=f"Missing IB_USER or IB_PASS in Vault credentials for follower {follower.id}",
+                        message=f"Missing IB_USER or IB_PASS in Vault credentials for follower {follower.id}",
                         severity=AlertSeverity.CRITICAL,
                     )
                     raise ValueError(f"Missing credentials in Vault for follower {follower.id}")
@@ -288,7 +289,7 @@ class GatewayManager:
                 # Final failure after retries
                 await self._publish_alert(
                     follower_id=follower.id,
-                    reason=f"Failed to retrieve IBKR credentials from Vault after retries: {str(e)}",
+                    message=f"Failed to retrieve IBKR credentials from Vault after retries: {str(e)}",
                     severity=AlertSeverity.CRITICAL,
                 )
                 raise
@@ -568,7 +569,7 @@ class GatewayManager:
                                         gateway.status = GatewayStatus.FAILED
                                         await self._publish_alert(
                                             follower_id=gateway.follower_id,
-                                            reason=f"Failed to reconnect after {gateway.connection_failures} failures: {str(e)}",
+                                            message=f"Failed to reconnect after {gateway.connection_failures} failures: {str(e)}",
                                             severity=AlertSeverity.CRITICAL,
                                         )
                             else:
@@ -763,13 +764,22 @@ class GatewayManager:
         except Exception as e:
             logger.error(f"Failed to remove gateway mapping: {e}")
 
-    async def _publish_alert(self, follower_id: str, reason: str, severity: AlertSeverity) -> None:
+    async def _publish_alert(
+        self,
+        follower_id: str,
+        message: str,
+        severity: AlertSeverity,
+        alert_type: AlertType = AlertType.GATEWAY_UNREACHABLE,
+    ) -> None:
         """Publish an alert for gateway issues.
 
         Args:
             follower_id: Follower ID
-            reason: Alert reason
+            message: Human-readable alert message (was 'reason' pre-#179)
             severity: Alert severity
+            alert_type: AlertType category — gateway-manager alerts default
+                to GATEWAY_UNREACHABLE since every call site describes a
+                connectivity / container-health failure.
         """
         try:
             # Import here to avoid circular dependency
@@ -778,14 +788,14 @@ class GatewayManager:
             redis_client = await get_redis_client()
             if redis_client:
                 alert = Alert(
+                    _id=str(uuid.uuid4()),
                     follower_id=follower_id,
-                    reason=reason,
                     severity=severity,
-                    service="gateway_manager",
-                    timestamp=time.time(),
+                    type=alert_type,
+                    message=message,
                 )
 
                 await redis_client.xadd("alerts", {"data": alert.model_dump_json()})
-                logger.info(f"Published alert for follower {follower_id}: {reason}")
+                logger.info(f"Published alert for follower {follower_id}: {message}")
         except Exception as e:
-            logger.error(f"Failed to publish alert: {e}")
+            logger.error(f"Failed to publish alert: {e}", exc_info=True)

--- a/tests/integration/test_watchdog_integration.py
+++ b/tests/integration/test_watchdog_integration.py
@@ -145,11 +145,10 @@ class TestWatchdogIntegration:
         alert = Alert.model_validate_json(alert_data["data"])
 
         assert alert.follower_id == "system"
-        assert "SERVICE_RESTART" in alert.reason
-        assert "test-service" in alert.reason
-        assert "3 consecutive health check failures" in alert.reason
+        assert "SERVICE_RESTART" in alert.message
+        assert "test-service" in alert.message
+        assert "3 consecutive health check failures" in alert.message
         assert alert.severity == AlertSeverity.WARNING
-        assert alert.service == "watchdog"
 
     @pytest.mark.asyncio
     async def test_service_recovery_after_failures(
@@ -187,8 +186,8 @@ class TestWatchdogIntegration:
         _, alert_data = alerts[0]
         alert = Alert.model_validate_json(alert_data["data"])
 
-        assert "SERVICE_RECOVERED" in alert.reason
-        assert "recovered after 2 failed health checks" in alert.reason
+        assert "SERVICE_RECOVERED" in alert.message
+        assert "recovered after 2 failed health checks" in alert.message
         assert alert.severity == AlertSeverity.INFO
 
     @pytest.mark.asyncio
@@ -223,7 +222,7 @@ class TestWatchdogIntegration:
         _, alert_data = alerts[0]
         alert = Alert.model_validate_json(alert_data["data"])
 
-        assert "SERVICE_RESTART_FAILED" in alert.reason
+        assert "SERVICE_RESTART_FAILED" in alert.message
         assert alert.severity == AlertSeverity.CRITICAL
 
     @pytest.mark.asyncio

--- a/tests/unit/test_executor_alerts.py
+++ b/tests/unit/test_executor_alerts.py
@@ -82,9 +82,8 @@ class TestExecutorAlerts:
 
         # Verify alert content
         assert alert.follower_id == "test_follower_123"
-        assert "NO_MARGIN" in alert.reason
+        assert "NO_MARGIN" in alert.message
         assert alert.severity == AlertSeverity.CRITICAL
-        assert alert.service == "executor"
 
     @pytest.mark.asyncio
     async def test_mid_price_too_low_publishes_alert(self, executor, fake_redis):
@@ -117,9 +116,9 @@ class TestExecutorAlerts:
         alert = Alert.model_validate_json(data["data"])
 
         assert alert.follower_id == "test_follower_123"
-        assert "MID_TOO_LOW" in alert.reason
-        assert "$0.30" in alert.reason
-        assert "$0.70" in alert.reason  # threshold
+        assert "MID_TOO_LOW" in alert.message
+        assert "$0.30" in alert.message
+        assert "$0.70" in alert.message  # threshold
         assert alert.severity == AlertSeverity.CRITICAL
 
     @pytest.mark.asyncio
@@ -162,8 +161,8 @@ class TestExecutorAlerts:
         alert = Alert.model_validate_json(data["data"])
 
         assert alert.follower_id == "test_follower_123"
-        assert "LIMIT_REACHED" in alert.reason
-        assert "All 2 attempts exhausted" in alert.reason
+        assert "LIMIT_REACHED" in alert.message
+        assert "All 2 attempts exhausted" in alert.message
         assert alert.severity == AlertSeverity.CRITICAL
 
     @pytest.mark.asyncio
@@ -189,7 +188,7 @@ class TestExecutorAlerts:
         alert = Alert.model_validate_json(data["data"])
 
         assert alert.follower_id == "test_follower_123"
-        assert "GATEWAY_UNREACHABLE" in alert.reason
+        assert "GATEWAY_UNREACHABLE" in alert.message
         assert alert.severity == AlertSeverity.CRITICAL
 
     @pytest.mark.asyncio
@@ -221,8 +220,8 @@ class TestExecutorAlerts:
         alert = Alert.model_validate_json(data["data"])
 
         assert alert.follower_id == "test_follower_123"
-        assert "GATEWAY_UNREACHABLE" in alert.reason
-        assert "Order rejected by IB" in alert.reason
+        assert "GATEWAY_UNREACHABLE" in alert.message
+        assert "Order rejected by IB" in alert.message
         assert alert.severity == AlertSeverity.CRITICAL
 
     @pytest.mark.asyncio
@@ -289,8 +288,8 @@ class TestExecutorAlerts:
 
         # Verify first alert (margin)
         assert alerts[0].follower_id == "follower_001"
-        assert "NO_MARGIN" in alerts[0].reason
+        assert "NO_MARGIN" in alerts[0].message
 
         # Verify second alert (MID)
         assert alerts[1].follower_id == "follower_002"
-        assert "MID_TOO_LOW" in alerts[1].reason
+        assert "MID_TOO_LOW" in alerts[1].message

--- a/tests/unit/test_executor_alerts.py
+++ b/tests/unit/test_executor_alerts.py
@@ -8,7 +8,7 @@ import pytest
 from fakeredis import aioredis as fakeredis
 from ib_insync import IB
 from spreadpilot_core.ibkr.client import IBKRClient, OrderStatus
-from spreadpilot_core.models.alert import Alert, AlertSeverity
+from spreadpilot_core.models.alert import Alert, AlertSeverity, AlertType
 from trading_bot.app.service.executor import VerticalSpreadExecutor
 
 
@@ -220,6 +220,11 @@ class TestExecutorAlerts:
         alert = Alert.model_validate_json(data["data"])
 
         assert alert.follower_id == "test_follower_123"
+        # This path is reached via a generic Exception from placeOrder which
+        # bubbles to the outer try/except in execute_vertical_spread and
+        # publishes via the GATEWAY_UNREACHABLE branch (not the limit-ladder
+        # IB REJECTED branch which uses NO_MARGIN).
+        assert alert.type == AlertType.GATEWAY_UNREACHABLE
         assert "GATEWAY_UNREACHABLE" in alert.message
         assert "Order rejected by IB" in alert.message
         assert alert.severity == AlertSeverity.CRITICAL

--- a/tests/unit/test_time_value_monitor.py
+++ b/tests/unit/test_time_value_monitor.py
@@ -194,8 +194,8 @@ class TestTimeValueMonitor:
         _, alert_data = alerts[0]
         alert = Alert.model_validate_json(alert_data["data"])
         assert alert.follower_id == "test_follower_123"
-        assert "TIME_VALUE_WARNING" in alert.reason
-        assert "$0.50" in alert.reason
+        assert "TIME_VALUE_WARNING" in alert.message
+        assert "$0.50" in alert.message
         assert alert.severity == AlertSeverity.WARNING
 
     @pytest.mark.asyncio
@@ -250,14 +250,14 @@ class TestTimeValueMonitor:
         # First alert: critical warning
         _, alert1_data = alerts[0]
         alert1 = Alert.model_validate_json(alert1_data["data"])
-        assert "TIME_VALUE_THRESHOLD" in alert1.reason
+        assert "TIME_VALUE_THRESHOLD" in alert1.message
         assert alert1.severity == AlertSeverity.CRITICAL
 
         # Second alert: liquidation success
         _, alert2_data = alerts[1]
         alert2 = Alert.model_validate_json(alert2_data["data"])
-        assert "TIME_VALUE_LIQUIDATION" in alert2.reason
-        assert "Successfully closed position" in alert2.reason
+        assert "TIME_VALUE_LIQUIDATION" in alert2.message
+        assert "Successfully closed position" in alert2.message
         assert alert2.severity == AlertSeverity.INFO
 
     @pytest.mark.asyncio

--- a/trading-bot/app/service/executor.py
+++ b/trading-bot/app/service/executor.py
@@ -4,6 +4,7 @@ import asyncio
 import datetime
 import json
 import time
+import uuid
 from typing import Any
 
 import ib_insync
@@ -11,7 +12,7 @@ import redis.asyncio as redis
 from ib_insync import LimitOrder
 from spreadpilot_core.ibkr.client import IBKRClient, OrderStatus
 from spreadpilot_core.logging import get_logger
-from spreadpilot_core.models.alert import Alert, AlertSeverity
+from spreadpilot_core.models.alert import Alert, AlertSeverity, AlertType
 
 logger = get_logger(__name__)
 
@@ -45,13 +46,18 @@ class VerticalSpreadExecutor:
             logger.info("Disconnected from Redis")
 
     async def _publish_alert(
-        self, follower_id: str, reason: str, severity: AlertSeverity = AlertSeverity.CRITICAL
+        self,
+        follower_id: str,
+        message: str,
+        alert_type: AlertType,
+        severity: AlertSeverity = AlertSeverity.CRITICAL,
     ):
         """Publish an alert to Redis alerts stream.
 
         Args:
             follower_id: Follower ID
-            reason: Alert reason
+            message: Human-readable alert message (was 'reason' pre-#179)
+            alert_type: The AlertType category (required by the Alert model)
             severity: Alert severity level
         """
         try:
@@ -60,21 +66,21 @@ class VerticalSpreadExecutor:
 
             # Create alert object
             alert = Alert(
+                _id=str(uuid.uuid4()),
                 follower_id=follower_id,
-                reason=reason,
                 severity=severity,
-                service="executor",
-                timestamp=time.time(),
+                type=alert_type,
+                message=message,
             )
 
             # Add to Redis stream
             await self.redis_client.xadd("alerts", {"data": alert.model_dump_json()})
 
             logger.info(
-                f"Published {severity.value} alert to Redis for follower {follower_id}: {reason}"
+                f"Published {severity.value} alert to Redis for follower {follower_id}: {message}"
             )
         except Exception as e:
-            logger.error(f"Failed to publish alert to Redis: {e}")
+            logger.error(f"Failed to publish alert to Redis: {e}", exc_info=True)
 
     async def execute_vertical_spread(
         self,
@@ -135,7 +141,8 @@ class VerticalSpreadExecutor:
                 # Publish alert for margin failure
                 await self._publish_alert(
                     follower_id=follower_id,
-                    reason=f"NO_MARGIN: {margin_check_result['error']}",
+                    message=f"NO_MARGIN: {margin_check_result['error']}",
+                    alert_type=AlertType.NO_MARGIN,
                     severity=AlertSeverity.CRITICAL,
                 )
                 return {
@@ -162,7 +169,8 @@ class VerticalSpreadExecutor:
                 # Publish alert for MID too low
                 await self._publish_alert(
                     follower_id=follower_id,
-                    reason=f"MID_TOO_LOW: MID price ${mid_price:.3f} below threshold ${min_price_threshold}",
+                    message=f"MID_TOO_LOW: MID price ${mid_price:.3f} below threshold ${min_price_threshold}",
+                    alert_type=AlertType.MID_TOO_LOW,
                     severity=AlertSeverity.CRITICAL,
                 )
                 return {
@@ -195,7 +203,8 @@ class VerticalSpreadExecutor:
             # Publish alert for gateway/execution error
             await self._publish_alert(
                 follower_id=follower_id,
-                reason=f"GATEWAY_UNREACHABLE: {str(e)}",
+                message=f"GATEWAY_UNREACHABLE: {str(e)}",
+                alert_type=AlertType.GATEWAY_UNREACHABLE,
                 severity=AlertSeverity.CRITICAL,
             )
             return {
@@ -431,7 +440,8 @@ class VerticalSpreadExecutor:
                     # Publish alert for limit price below threshold
                     await self._publish_alert(
                         follower_id=follower_id,
-                        reason=f"MID_TOO_LOW: Limit price ${current_limit_price:.3f} fell below threshold ${min_price_threshold} on attempt {attempt}",
+                        message=f"MID_TOO_LOW: Limit price ${current_limit_price:.3f} fell below threshold ${min_price_threshold} on attempt {attempt}",
+                        alert_type=AlertType.MID_TOO_LOW,
                         severity=AlertSeverity.CRITICAL,
                     )
                     return {
@@ -510,7 +520,11 @@ class VerticalSpreadExecutor:
                     if is_ib_rejection:
                         await self._publish_alert(
                             follower_id=follower_id,
-                            reason=f"REJECTED: IB rejected order on attempt {attempt}. Reason: {trade.orderStatus.whyHeld or 'Unknown'}",
+                            message=f"REJECTED: IB rejected order on attempt {attempt}. Reason: {trade.orderStatus.whyHeld or 'Unknown'}",
+                            # IB rejection most commonly maps to margin/credit issues;
+                            # NO_MARGIN is the closest enum value until a dedicated
+                            # REJECTED type is introduced (see #191).
+                            alert_type=AlertType.NO_MARGIN,
                             severity=AlertSeverity.CRITICAL,
                         )
                         return {
@@ -558,7 +572,8 @@ class VerticalSpreadExecutor:
             # All attempts exhausted
             await self._publish_alert(
                 follower_id=follower_id,
-                reason=f"LIMIT_REACHED: All {max_attempts} attempts exhausted. Initial limit: ${initial_mid_price:.3f}, Final limit: ${current_limit_price:.3f}",
+                message=f"LIMIT_REACHED: All {max_attempts} attempts exhausted. Initial limit: ${initial_mid_price:.3f}, Final limit: ${current_limit_price:.3f}",
+                alert_type=AlertType.LIMIT_REACHED,
                 severity=AlertSeverity.CRITICAL,
             )
 

--- a/trading-bot/app/service/time_value_monitor.py
+++ b/trading-bot/app/service/time_value_monitor.py
@@ -6,6 +6,7 @@ Monitors open positions and automatically closes them when time value falls belo
 import asyncio
 import json
 import time
+import uuid
 from enum import StrEnum
 from typing import Any
 
@@ -15,7 +16,7 @@ from apscheduler.schedulers.asyncio import AsyncIOScheduler
 from apscheduler.triggers.interval import IntervalTrigger
 from ib_insync import Contract, MarketOrder
 from spreadpilot_core.logging import get_logger
-from spreadpilot_core.models.alert import Alert, AlertSeverity
+from spreadpilot_core.models.alert import Alert, AlertSeverity, AlertType
 
 logger = get_logger(__name__)
 
@@ -311,19 +312,20 @@ class TimeValueMonitor:
             TimeValueStatus.CRITICAL: AlertSeverity.CRITICAL,
         }
 
-        # Create reason based on status
+        # Create message based on status
         if status == TimeValueStatus.CRITICAL:
-            reason = f"TIME_VALUE_THRESHOLD: Position {contract.symbol} {contract.strike}{contract.right} has critical time value ${time_value:.2f} <= $0.10. Closing position."
+            message = f"TIME_VALUE_THRESHOLD: Position {contract.symbol} {contract.strike}{contract.right} has critical time value ${time_value:.2f} <= $0.10. Closing position."
         else:
-            reason = f"TIME_VALUE_WARNING: Position {contract.symbol} {contract.strike}{contract.right} has low time value ${time_value:.2f}"
+            message = f"TIME_VALUE_WARNING: Position {contract.symbol} {contract.strike}{contract.right} has low time value ${time_value:.2f}"
 
-        # Create alert
+        # Create alert — time-value threshold breach maps to LIMIT_REACHED
+        # (the closest AlertType value for "position-level threshold crossed").
         alert = Alert(
+            _id=str(uuid.uuid4()),
             follower_id=follower_id,
-            reason=reason,
             severity=severity_map[status],
-            service="time_value_monitor",
-            timestamp=time.time(),
+            type=AlertType.LIMIT_REACHED,
+            message=message,
         )
 
         try:
@@ -382,13 +384,14 @@ class TimeValueMonitor:
                     fill_price=trade.orderStatus.avgFillPrice,
                 )
 
-                # Publish success alert
+                # Publish success alert (informational — same AlertType as the
+                # threshold breach that triggered this liquidation, INFO severity).
                 alert = Alert(
+                    _id=str(uuid.uuid4()),
                     follower_id=follower_id,
-                    reason=f"TIME_VALUE_LIQUIDATION: Successfully closed position {contract.symbol} {contract.strike}{contract.right} at ${trade.orderStatus.avgFillPrice:.2f} due to TV ${time_value:.2f} <= $0.10",
                     severity=AlertSeverity.INFO,
-                    service="time_value_monitor",
-                    timestamp=time.time(),
+                    type=AlertType.LIMIT_REACHED,
+                    message=f"TIME_VALUE_LIQUIDATION: Successfully closed position {contract.symbol} {contract.strike}{contract.right} at ${trade.orderStatus.avgFillPrice:.2f} due to TV ${time_value:.2f} <= $0.10",
                 )
 
                 if self.redis_client:

--- a/watchdog/main.py
+++ b/watchdog/main.py
@@ -7,11 +7,12 @@ import json
 import logging
 import os
 import time
+import uuid
 
 import docker
 import httpx
 import redis.asyncio as redis
-from spreadpilot_core.models.alert import Alert, AlertSeverity
+from spreadpilot_core.models.alert import Alert, AlertSeverity, AlertType
 
 # Configure logging
 logging.basicConfig(
@@ -137,32 +138,39 @@ class ContainerWatchdog:
             return False
 
     async def publish_alert(
-        self, service_name: str, reason: str, severity: AlertSeverity = AlertSeverity.CRITICAL
+        self,
+        service_name: str,
+        message: str,
+        severity: AlertSeverity = AlertSeverity.CRITICAL,
+        alert_type: AlertType = AlertType.COMPONENT_DOWN,
     ):
         """
         Publish an alert to Redis stream.
 
         Args:
-            service_name: Name of the service/container
-            reason: Alert reason
+            service_name: Name of the service/container (embedded in the message
+                since the Alert model does not have a dedicated service field).
+            message: Human-readable alert message (was 'reason' pre-#179)
             severity: Alert severity level
+            alert_type: AlertType category (default COMPONENT_DOWN since the
+                watchdog observes service-health events)
         """
         alert = Alert(
+            _id=str(uuid.uuid4()),
             follower_id="system",  # System-level alert
-            reason=reason,
             severity=severity,
-            service="watchdog",
-            timestamp=time.time(),
+            type=alert_type,
+            message=f"[{service_name}] {message}",
         )
 
         try:
             if self.redis_client:
                 await self.redis_client.xadd("alerts", {"data": alert.model_dump_json()})
-                logger.info(f"Published alert: {reason}")
+                logger.info(f"Published alert: {message}")
             else:
                 logger.warning("Redis not connected, alert not published")
         except Exception as e:
-            logger.error(f"Failed to publish alert to Redis: {e}")
+            logger.error(f"Failed to publish alert to Redis: {e}", exc_info=True)
 
     async def monitor_container(self, container):
         """
@@ -187,7 +195,7 @@ class ContainerWatchdog:
                 )
                 await self.publish_alert(
                     service_name=container_name,
-                    reason=f"SERVICE_RECOVERED: {container_name} recovered after {self.failure_counts[container_name]} failed health checks",
+                    message=f"SERVICE_RECOVERED: {container_name} recovered after {self.failure_counts[container_name]} failed health checks",
                     severity=AlertSeverity.INFO,
                 )
             self.failure_counts[container_name] = 0
@@ -212,14 +220,14 @@ class ContainerWatchdog:
                 if restart_success:
                     await self.publish_alert(
                         service_name=container_name,
-                        reason=f"SERVICE_RESTART: {container_name} was restarted after {MAX_CONSECUTIVE_FAILURES} consecutive health check failures",
+                        message=f"SERVICE_RESTART: {container_name} was restarted after {MAX_CONSECUTIVE_FAILURES} consecutive health check failures",
                         severity=AlertSeverity.WARNING,
                     )
                     self.failure_counts[container_name] = 0
                 else:
                     await self.publish_alert(
                         service_name=container_name,
-                        reason=f"SERVICE_RESTART_FAILED: Failed to restart {container_name} after {MAX_CONSECUTIVE_FAILURES} consecutive health check failures",
+                        message=f"SERVICE_RESTART_FAILED: Failed to restart {container_name} after {MAX_CONSECUTIVE_FAILURES} consecutive health check failures",
                         severity=AlertSeverity.CRITICAL,
                     )
 

--- a/watchdog/tests/test_watchdog_redis.py
+++ b/watchdog/tests/test_watchdog_redis.py
@@ -49,14 +49,13 @@ class TestWatchdogRedisAlerts:
         alert_json = data["data"]
         alert = Alert.model_validate_json(alert_json)
 
-        assert alert.service == "watchdog"
         assert alert.follower_id == "system"
-        assert "RECOVERED" in alert.reason
-        assert "Trading Bot" in alert.reason
+        assert "RECOVERED" in alert.message
+        assert "Trading Bot" in alert.message
         assert alert.severity == AlertSeverity.INFO
-        assert alert.details["component_name"] == "trading_bot"
-        assert alert.details["action"] == "recovery"
-        assert alert.details["success"] is True
+        assert "service=trading_bot" in alert.message
+        assert "action=recovery" in alert.message
+        assert "success=True" in alert.message
 
     @pytest.mark.asyncio
     async def test_publish_restart_success_alert(self, watchdog_with_redis, fake_redis):
@@ -73,10 +72,10 @@ class TestWatchdogRedisAlerts:
         alert = Alert.model_validate_json(data["data"])
 
         assert alert.severity == AlertSeverity.WARNING
-        assert "RESTARTED" in alert.reason
-        assert "Admin API" in alert.reason
-        assert alert.details["consecutive_failures"] == 3
-        assert alert.details["success"] is True
+        assert "RESTARTED" in alert.message
+        assert "Admin API" in alert.message
+        assert "consecutive_failures=3" in alert.message
+        assert "success=True" in alert.message
 
     @pytest.mark.asyncio
     async def test_publish_restart_failure_alert(self, watchdog_with_redis, fake_redis):
@@ -92,9 +91,9 @@ class TestWatchdogRedisAlerts:
         alert = Alert.model_validate_json(data["data"])
 
         assert alert.severity == AlertSeverity.CRITICAL
-        assert "RESTART_FAILED" in alert.reason
-        assert "Report Worker" in alert.reason
-        assert alert.details["success"] is False
+        assert "RESTART_FAILED" in alert.message
+        assert "Report Worker" in alert.message
+        assert "success=False" in alert.message
 
     @pytest.mark.asyncio
     async def test_monitor_service_publishes_alerts(self, watchdog_with_redis, fake_redis):
@@ -113,7 +112,7 @@ class TestWatchdogRedisAlerts:
 
         alert = Alert.model_validate_json(messages[0][1]["data"])
         assert alert.severity == AlertSeverity.WARNING
-        assert "RESTARTED" in alert.reason
+        assert "RESTARTED" in alert.message
 
     @pytest.mark.asyncio
     async def test_multiple_alerts_published(self, watchdog_with_redis, fake_redis):
@@ -131,15 +130,17 @@ class TestWatchdogRedisAlerts:
         alerts = [Alert.model_validate_json(msg[1]["data"]) for msg in messages]
 
         # Recovery alert
-        recovery_alert = next(a for a in alerts if "RECOVERED" in a.reason)
+        recovery_alert = next(a for a in alerts if "RECOVERED" in a.message)
         assert recovery_alert.severity == AlertSeverity.INFO
 
         # Failed restart alert
-        failed_alert = next(a for a in alerts if "RESTART_FAILED" in a.reason)
+        failed_alert = next(a for a in alerts if "RESTART_FAILED" in a.message)
         assert failed_alert.severity == AlertSeverity.CRITICAL
 
         # Successful restart alert
-        success_alert = next(a for a in alerts if "RESTARTED" in a.reason and a.details["success"])
+        success_alert = next(
+            a for a in alerts if "RESTARTED" in a.message and "success=True" in a.message
+        )
         assert success_alert.severity == AlertSeverity.WARNING
 
     @pytest.mark.asyncio
@@ -150,8 +151,8 @@ class TestWatchdogRedisAlerts:
         messages = await fake_redis.xrange("alerts")
         alert = Alert.model_validate_json(messages[0][1]["data"])
 
-        assert "health_url" in alert.details
-        assert alert.details["health_url"] == "http://trading-bot:8080/health"
+        assert "health_url=" in alert.message
+        assert "health_url=http://trading-bot:8080/health" in alert.message
 
     @pytest.mark.asyncio
     async def test_redis_connection_error_handled(self, watchdog_with_redis):

--- a/watchdog/watchdog.py
+++ b/watchdog/watchdog.py
@@ -7,6 +7,7 @@ import logging
 import os
 import subprocess
 import sys
+import uuid
 from datetime import datetime
 
 import httpx
@@ -180,38 +181,40 @@ class ServiceWatchdog:
         """
         service_config = SERVICES[service_name]
 
-        # Determine severity based on action and success
+        # Determine severity based on action and success. AlertSeverity has
+        # only INFO / WARNING / CRITICAL; the 'down' case maps to CRITICAL.
         if action == "recovery":
             severity = AlertSeverity.INFO
-            reason = f"RECOVERED: {service_config['display_name']} is now healthy"
+            message = f"RECOVERED: {service_config['display_name']} is now healthy"
         elif action == "restart" and success:
             severity = AlertSeverity.WARNING
-            reason = (
+            message = (
                 f"RESTARTED: {service_config['display_name']} was "
                 "successfully restarted after failures"
             )
         elif action == "restart" and not success:
             severity = AlertSeverity.CRITICAL
-            reason = f"RESTART_FAILED: Failed to restart {service_config['display_name']}"
+            message = f"RESTART_FAILED: Failed to restart {service_config['display_name']}"
         else:
-            severity = AlertSeverity.ERROR
-            reason = f"DOWN: {service_config['display_name']} is not responding"
+            severity = AlertSeverity.CRITICAL
+            message = f"DOWN: {service_config['display_name']} is not responding"
 
-        # Create alert compatible with alert router
+        # Create alert compatible with alert router.
+        # The legacy 'details' payload (component_name, container_name, action,
+        # success, consecutive_failures, health_url) has no field on the current
+        # Alert model — it is folded into the message string so nothing is lost.
         alert = Alert(
-            service="watchdog",
+            _id=str(uuid.uuid4()),
             follower_id="system",  # System-level alert
-            reason=reason,
             severity=severity,
-            timestamp=datetime.utcnow(),
-            details={
-                "component_name": service_name,
-                "container_name": service_config["container_name"],
-                "action": action,
-                "success": success,
-                "consecutive_failures": self.failure_counts[service_name],
-                "health_url": service_config["health_url"],
-            },
+            type=AlertType.COMPONENT_DOWN,
+            message=(
+                f"{message} "
+                f"[service={service_name}, container={service_config['container_name']}, "
+                f"action={action}, success={success}, "
+                f"consecutive_failures={self.failure_counts[service_name]}, "
+                f"health_url={service_config['health_url']}]"
+            ),
         )
 
         # Publish to Redis Stream for alert router
@@ -219,7 +222,7 @@ class ServiceWatchdog:
             if self.redis_client:
                 alert_json = alert.model_dump_json()
                 await self.redis_client.xadd(REDIS_ALERT_STREAM, {"data": alert_json})
-                logger.info(f"Alert published to Redis: {alert.reason}")
+                logger.info(f"Alert published to Redis: {alert.message}")
             else:
                 logger.warning("Redis not connected, alert not published")
         except Exception as e:

--- a/watchdog/watchdog.py
+++ b/watchdog/watchdog.py
@@ -13,7 +13,7 @@ from datetime import datetime
 import httpx
 import redis.asyncio as redis
 from motor.motor_asyncio import AsyncIOMotorClient
-from spreadpilot_core.models.alert import Alert, AlertEvent, AlertSeverity, AlertType
+from spreadpilot_core.models.alert import Alert, AlertSeverity, AlertType
 
 # Configure logging
 logging.basicConfig(
@@ -226,27 +226,19 @@ class ServiceWatchdog:
             else:
                 logger.warning("Redis not connected, alert not published")
         except Exception as e:
-            logger.error(f"Failed to publish alert to Redis: {e}")
+            logger.error(f"Failed to publish alert to Redis: {e}", exc_info=True)
 
-        # Also store in MongoDB for persistence
+        # Also store in MongoDB for persistence.
+        # Uses the Alert document directly (model_dump with the _id alias for
+        # Mongo's _id field). The legacy path used AlertEvent with timestamp/
+        # reason/details/COMPONENT_RECOVERED — all of which are absent from the
+        # current models and would raise AttributeError / invalid-enum errors.
         try:
             if self.mongo_db:
-                # Store as AlertEvent for MongoDB compatibility
-                event_type = (
-                    AlertType.COMPONENT_RECOVERED
-                    if action == "recovery"
-                    else AlertType.COMPONENT_DOWN
-                )
-                alert_event = AlertEvent(
-                    event_type=event_type,
-                    timestamp=alert.timestamp,
-                    message=alert.reason,
-                    params=alert.details,
-                )
-                await self.mongo_db.alerts.insert_one(alert_event.dict())
-                logger.info(f"Alert stored in MongoDB for persistence")
+                await self.mongo_db.alerts.insert_one(alert.model_dump(by_alias=True))
+                logger.info("Alert stored in MongoDB for persistence")
         except Exception as e:
-            logger.error(f"Failed to store alert in MongoDB: {e}")
+            logger.error(f"Failed to store alert in MongoDB: {e}", exc_info=True)
 
     async def monitor_service(self, service_name: str):
         """


### PR DESCRIPTION
## Summary
Fixes #190 (HIGH severity — alerts silently dropped in production).

Five production files constructed \`Alert(reason=, service=, timestamp=)\` against fields that no longer exist on \`spreadpilot_core.models.alert.Alert\` and omitted the now-required \`id\` / \`type\` fields. Every call site hit Pydantic \`ValidationError\` at runtime; surrounding \`except Exception\` handlers swallowed the error, so in production alerts from trading-bot executor, time-value monitor, watchdog, and gateway-manager **never reached the Redis stream**.

## Field mapping
| Old kwarg | New kwarg | Note |
|---|---|---|
| \`reason=\` | \`message=\` | rename |
| \`timestamp=\` (unix / datetime) | *(gone)* | \`created_at\` auto-populated by model default |
| \`service=\` | *(gone — folded into message)* | No equivalent field; #191 proposes \`source_service\` |
| \`details={}\` (watchdog) | *(gone — folded into message)* | No equivalent field on current model |
| missing \`_id\` | \`_id=str(uuid.uuid4())\` | required |
| missing \`type\` | \`type=AlertType.*\` | required |

## AlertType mapping (best effort over 10 existing enum values)
| Call site | AlertType |
|---|---|
| \`executor.py\` margin check fail | \`NO_MARGIN\` |
| \`executor.py\` mid price low (×2) | \`MID_TOO_LOW\` |
| \`executor.py\` execution exception | \`GATEWAY_UNREACHABLE\` |
| \`executor.py\` IB REJECTED | \`NO_MARGIN\` (closest; fine-grained type deferred to #191) |
| \`executor.py\` ladder exhausted | \`LIMIT_REACHED\` |
| \`time_value_monitor.py\` threshold breach / liquidation | \`LIMIT_REACHED\` |
| \`watchdog.py\` / \`watchdog/main.py\` | \`COMPONENT_DOWN\` |
| \`gateway_manager.py\` | \`GATEWAY_UNREACHABLE\` |

## API changes (internal)
- \`executor._publish_alert\`: new required \`alert_type: AlertType\` parameter
- \`watchdog/main.publish_alert\`: new optional \`alert_type\` (default \`COMPONENT_DOWN\`), old \`reason=\` renamed to \`message=\`
- \`gateway_manager._publish_alert\`: new optional \`alert_type\` (default \`GATEWAY_UNREACHABLE\`), \`reason=\` → \`message=\`

All caller sites (internal — no external API) updated in the same commit.

## Watchdog special case
\`watchdog/watchdog.py\` additionally:
1. Dropped \`AlertSeverity.ERROR\` — not in the enum (only \`INFO/WARNING/CRITICAL\`). \`DOWN\` now maps to \`CRITICAL\`.
2. Dropped the \`details={...}\` dict. Its contents (component_name, container_name, action, success, consecutive_failures, health_url) are folded into the \`message\` string so no information is lost.

## Tests updated
Three test files asserted \`alert.reason\` / \`alert.service\` which don't exist on the current model:
- \`tests/unit/test_executor_alerts.py\`
- \`tests/unit/test_time_value_monitor.py\`
- \`tests/integration/test_watchdog_integration.py\`

Rewritten to \`alert.message\`. \`assert alert.service == ...\` lines dropped entirely (no equivalent).

## Test results
\`test_margin_check_failure_publishes_alert\` now **PASSES** — proving Alert is correctly constructed and reaches the Redis stream. The logs even show:
\`\`\`
INFO executor.py:79 Published CRITICAL alert to Redis for follower test_follower_123: NO_MARGIN: ...
\`\`\`

6 remaining failures in \`test_executor_alerts.py\` are all traceable to **#180** (ib_insync \`Bag.__init__\` signature change) — a pre-existing, orthogonal bug not in the scope of this PR.

## Smoke verification
\`\`\`python
Alert(_id=..., follower_id=..., severity=AlertSeverity.CRITICAL, type=AlertType.NO_MARGIN, message='test')  # OK
Alert(_id=..., follower_id='system', severity=AlertSeverity.INFO, type=AlertType.COMPONENT_DOWN, message='test')  # OK
# ... all 6 shapes build clean
\`\`\`

## Acceptance criteria (all green)
- [x] Zero \`Alert(.*reason=|service=|timestamp=)\` in production code
- [x] All 6 call sites build valid Alert without ValidationError
- [x] \`_publish_alert\` signatures accept explicit \`alert_type\`
- [x] AlertType mapping is semantically closest available value
- [x] No invented fields (details dropped, not added to model)
- [x] \`test_margin_check_failure_publishes_alert\` now passes (regression guard)
- [x] Ruff + black clean on all changed files

## Related issues
- **Closes #190**
- Partially unblocks **#180** (6 tests still fail on Bag mock — separate issue)
- Partially unblocks **#182**, **#186** (same root cause pattern in gateway_manager / time_value_monitor producers — now fixed)
- **#191** tracks adding \`source_service\` to the Alert model (follow-up refinement)

🤖 Generated with [Claude Code](https://claude.com/claude-code)