### PR TITLE
fix(test): align freeze_time literals with UTC for pnl_service tests (#184)

### DIFF
--- a/tests/unit/test_pnl_service_redis.py
+++ b/tests/unit/test_pnl_service_redis.py
@@ -183,7 +183,9 @@ class TestPnLServiceRedisStreams:
                 is_open = pnl_service._is_market_open()
                 assert not is_open
 
-    @freeze_time("2025-06-29 16:30:00")  # Daily rollup time (4:30 PM ET)
+    # freeze_time interprets the literal as UTC. June = EDT (UTC-4), so to
+    # observe 16:30 ET the UTC clock must be 20:30.
+    @freeze_time("2025-06-29 20:30:00")  # 16:30 ET / 20:30 UTC (EDT = UTC-4)
     @pytest.mark.asyncio
     async def test_daily_rollup_scheduling(self, pnl_service):
         """Test daily rollup scheduling at 16:30 ET."""
@@ -363,7 +365,9 @@ class TestPnLServiceRedisStreams:
                     # Expected - should handle gracefully
                     pass
 
-    @freeze_time("2025-01-01 00:10:00")  # Monthly rollup time
+    # freeze_time interprets the literal as UTC. January = EST (UTC-5), so to
+    # observe 2025-01-01 00:10 ET the UTC clock must be 2025-01-01 05:10.
+    @freeze_time("2025-01-01 05:10:00")  # 00:10 ET / 05:10 UTC (EST = UTC-5)
     @pytest.mark.asyncio
     async def test_monthly_rollup_scheduling(self, pnl_service):
         """Test monthly rollup scheduling on 1st at 00:10 ET."""


### PR DESCRIPTION
## Summary
Fixes #184. Both `test_daily_rollup_scheduling` and `test_monthly_rollup_scheduling` hardcoded `@freeze_time("YYYY-MM-DD HH:MM:SS")` as if the literal were ET. freezegun interprets bare literals as **UTC**, so when the test called `datetime.now(pytz.timezone("US/Eastern"))` the result was shifted by −4h (EDT) or −5h (EST), producing the errors in the issue:
- `assert 12 == 16` (16:30 ET → 20:30 UTC → back to 16:30 but the test was getting 12:30)
- `assert 31 == 1` (00:10 ET Jan 1 → 05:10 UTC Jan 1 → back to 00:10 Jan 1 but the test was getting Dec 31 19:10)

## Fix
Shift the frozen UTC timestamps so the ET conversion lands on the intended wall-clock value:
- **Daily rollup** (16:30 ET, June = EDT, UTC−4): `@freeze_time("2025-06-29 20:30:00")`
- **Monthly rollup** (00:10 ET, January = EST, UTC−5): `@freeze_time("2025-01-01 05:10:00")`

Added inline comments explaining the DST offset so the next reader doesn't rediscover the trap.

## Acceptance criteria
- [x] Both tests pass regardless of system clock
- [x] DST is correctly accounted for (EDT vs EST)
- [x] No production code changed
- [x] Ruff + black clean

## Test run (local)
\`\`\`
tests/unit/test_pnl_service_redis.py::TestPnLServiceRedisStreams::test_daily_rollup_scheduling    PASSED
tests/unit/test_pnl_service_redis.py::TestPnLServiceRedisStreams::test_monthly_rollup_scheduling  PASSED
\`\`\`

Closes #184

🤖 Generated with [Claude Code](https://claude.com/claude-code)