### PR TITLE
fix: time_value_monitor tests + latent logger kwargs bug (#186)

### DIFF
--- a/tests/unit/test_time_value_monitor.py
+++ b/tests/unit/test_time_value_monitor.py
@@ -26,8 +26,12 @@ def mock_service():
     service = MagicMock()
     service.active_followers = {"test_follower_123": MagicMock(id="test_follower_123")}
 
-    # Mock IBKR manager
+    # Mock IBKR manager. `get_client` is awaited by
+    # TimeValueMonitor._check_follower_positions, so it must be an AsyncMock;
+    # a plain MagicMock returns a non-awaitable child mock and fails with
+    # "object MagicMock can't be used in 'await' expression".
     mock_ibkr_manager = MagicMock()
+    mock_ibkr_manager.get_client = AsyncMock()
     service.ibkr_manager = mock_ibkr_manager
 
     return service
@@ -137,8 +141,9 @@ class TestTimeValueMonitor:
 
         mock_ibkr_client.ib.positions.return_value = [mock_position]
 
-        # Mock prices: option at $3.50, underlying at $455, intrinsic = $5, TV = -$1.50
-        mock_ibkr_client.get_market_price.side_effect = [3.50, 455.0]
+        # Mock prices: option at $8.00, underlying at $455, intrinsic = $5, TV = $3.00
+        # (TV > $1.00 is the SAFE threshold)
+        mock_ibkr_client.get_market_price.side_effect = [8.00, 455.0]
 
         # Run check
         await tv_monitor._check_follower_positions(
@@ -150,7 +155,7 @@ class TestTimeValueMonitor:
         assert status_key is not None
         status_data = json.loads(status_key)
         assert status_data["status"] == "SAFE"
-        assert abs(status_data["time_value"] - (-1.50)) < 0.01
+        assert abs(status_data["time_value"] - 3.00) < 0.01
 
         # No alerts should be published for SAFE status
         alerts = await fake_redis.xrange("alerts")

--- a/trading-bot/app/service/time_value_monitor.py
+++ b/trading-bot/app/service/time_value_monitor.py
@@ -194,15 +194,17 @@ class TimeValueMonitor:
 
             logger.info(
                 "Position time value check",
-                follower_id=follower_id,
-                symbol=contract.symbol,
-                strike=contract.strike,
-                right=contract.right,
-                position_qty=position.position,
-                market_price=market_price,
-                intrinsic_value=intrinsic_value,
-                time_value=time_value,
-                status=status,
+                extra={
+                    "follower_id": follower_id,
+                    "symbol": contract.symbol,
+                    "strike": contract.strike,
+                    "right": contract.right,
+                    "position_qty": position.position,
+                    "market_price": market_price,
+                    "intrinsic_value": intrinsic_value,
+                    "time_value": time_value,
+                    "status": status,
+                },
             )
 
             # Publish status to Redis key
@@ -223,10 +225,12 @@ class TimeValueMonitor:
         except Exception as e:
             logger.error(
                 f"Error checking time value for position: {e}",
-                follower_id=follower_id,
-                contract_symbol=contract.symbol,
-                strike=contract.strike,
-                right=contract.right,
+                extra={
+                    "follower_id": follower_id,
+                    "contract_symbol": contract.symbol,
+                    "strike": contract.strike,
+                    "right": contract.right,
+                },
                 exc_info=True,
             )
 
@@ -354,12 +358,14 @@ class TimeValueMonitor:
         """
         logger.warning(
             "Closing position due to critical time value",
-            follower_id=follower_id,
-            symbol=contract.symbol,
-            strike=contract.strike,
-            right=contract.right,
-            position_qty=position_qty,
-            time_value=time_value,
+            extra={
+                "follower_id": follower_id,
+                "symbol": contract.symbol,
+                "strike": contract.strike,
+                "right": contract.right,
+                "position_qty": position_qty,
+                "time_value": time_value,
+            },
         )
 
         try:
@@ -379,9 +385,11 @@ class TimeValueMonitor:
             if trade.orderStatus.status == "Filled":
                 logger.info(
                     "Successfully closed position",
-                    follower_id=follower_id,
-                    order_id=trade.order.orderId,
-                    fill_price=trade.orderStatus.avgFillPrice,
+                    extra={
+                        "follower_id": follower_id,
+                        "order_id": trade.order.orderId,
+                        "fill_price": trade.orderStatus.avgFillPrice,
+                    },
                 )
 
                 # Publish success alert (informational — same AlertType as the
@@ -399,17 +407,21 @@ class TimeValueMonitor:
             else:
                 logger.error(
                     "Failed to close position",
-                    follower_id=follower_id,
-                    order_status=trade.orderStatus.status,
-                    order_id=trade.order.orderId,
+                    extra={
+                        "follower_id": follower_id,
+                        "order_status": trade.orderStatus.status,
+                        "order_id": trade.order.orderId,
+                    },
                 )
 
         except Exception as e:
             logger.error(
                 f"Error closing position: {e}",
-                follower_id=follower_id,
-                contract_symbol=contract.symbol,
-                strike=contract.strike,
-                right=contract.right,
+                extra={
+                    "follower_id": follower_id,
+                    "contract_symbol": contract.symbol,
+                    "strike": contract.strike,
+                    "right": contract.right,
+                },
                 exc_info=True,
             )


### PR DESCRIPTION
## Summary
Closes #186. What started as "MagicMock awaited as coroutine" turned out to be three layered problems that all had to be fixed together, because each one masked the next.

## Problems & fixes

### 1. Test fixture (the stated scope of #186)
`mock_service` built `ibkr_manager = MagicMock()`, but production does `await self.service.ibkr_manager.get_client(follower_id)`. A plain `MagicMock` returns a child mock that isn't awaitable. **Fix**: `mock_ibkr_manager.get_client = AsyncMock()`.

### 2. Latent production bug (surfaced once #1 was fixed)
`time_value_monitor.py` made **5 logger calls with legacy structured-logger kwargs** (`follower_id=...`, `symbol=...`, etc.) that stdlib `logging.Logger` rejects with `TypeError: Logger._log() got an unexpected keyword argument 'follower_id'`. These were masked by the broken mock path — the test never reached them before. The old `StructuredLogger` class was removed in an earlier refactor but the call sites were not migrated. **Fix**: converted all 5 calls to the stdlib `extra={...}` pattern already used consistently by `executor.py`. This was a real latent production bug: any time `_check_position_time_value` or `_close_position` actually logged, it would have raised.

### 3. Logically broken test data (surfaced once #1 and #2 were fixed)
`test_position_check_with_safe_tv` mocked a long ITM call with `market_price=$3.50` and `intrinsic=$5.00` → `TV = -$1.50`, then asserted `status == SAFE`. Negative time value is physically impossible for a long ITM option (would be an arbitrage), and production correctly categorises TV ≤ $0.10 as CRITICAL including negatives. **Fix**: set `market_price=$8.00` → TV = $3.00 > $1.00 (the real SAFE threshold) and adjusted the assertion.

## Test results
- Before: 3/9 passing on main
- After: **9/9 passing** locally

## Acceptance criteria
- [x] All 6 originally-failing tests now pass
- [x] No existing passing tests regress (verified: 3 original passes still green)
- [x] No production API changes — only internal logger call pattern
- [x] Ruff + black clean

## Operational note
Fix #2 means time_value_monitor alerts, previously silently broken every time they tried to log (masked by `except Exception` handlers), now actually propagate their context. Similar to the #190 pattern: the same refactor that removed `StructuredLogger` left callers in inconsistent state.

Closes #186

🤖 Generated with [Claude Code](https://claude.com/claude-code)