### PR TITLE
fix(trading-bot): align executor with ib_insync 0.9.86 Bag API (#180)

### DIFF
--- a/trading-bot/app/service/executor.py
+++ b/trading-bot/app/service/executor.py
@@ -138,16 +138,27 @@ class VerticalSpreadExecutor:
             )
 
             if not margin_check_result["success"]:
-                # Publish alert for margin failure
-                await self._publish_alert(
-                    follower_id=follower_id,
-                    message=f"NO_MARGIN: {margin_check_result['error']}",
-                    alert_type=AlertType.NO_MARGIN,
-                    severity=AlertSeverity.CRITICAL,
-                )
+                # Connection-loss errors surface from the whatIf path too:
+                # route them to GATEWAY_UNREACHABLE instead of NO_MARGIN so the
+                # alert reflects the actual failure domain.
+                error_msg = margin_check_result["error"] or ""
+                if "Not connected to IB Gateway" in error_msg:
+                    await self._publish_alert(
+                        follower_id=follower_id,
+                        message=f"GATEWAY_UNREACHABLE: {error_msg}",
+                        alert_type=AlertType.GATEWAY_UNREACHABLE,
+                        severity=AlertSeverity.CRITICAL,
+                    )
+                else:
+                    await self._publish_alert(
+                        follower_id=follower_id,
+                        message=f"NO_MARGIN: {error_msg}",
+                        alert_type=AlertType.NO_MARGIN,
+                        severity=AlertSeverity.CRITICAL,
+                    )
                 return {
                     "status": OrderStatus.REJECTED,
-                    "error": f"Margin check failed: {margin_check_result['error']}",
+                    "error": f"Margin check failed: {error_msg}",
                     "follower_id": follower_id,
                     "margin_details": margin_check_result,
                 }
@@ -169,7 +180,7 @@ class VerticalSpreadExecutor:
                 # Publish alert for MID too low
                 await self._publish_alert(
                     follower_id=follower_id,
-                    message=f"MID_TOO_LOW: MID price ${mid_price:.3f} below threshold ${min_price_threshold}",
+                    message=f"MID_TOO_LOW: MID price ${mid_price:.3f} below threshold ${min_price_threshold:.2f}",
                     alert_type=AlertType.MID_TOO_LOW,
                     severity=AlertSeverity.CRITICAL,
                 )
@@ -252,9 +263,23 @@ class VerticalSpreadExecutor:
             short_contract = self.ibkr_client._get_qqq_option_contract(strike_short, short_right)
 
             # Create combo contract for spread
-            combo_contract = ib_insync.Bag("QQQ", "SMART", "USD")
-            combo_contract.addLeg(long_contract, 1)  # Buy long leg
-            combo_contract.addLeg(short_contract, -1)  # Sell short leg
+            combo_contract = ib_insync.Bag(symbol="QQQ", exchange="SMART", currency="USD")
+            combo_contract.comboLegs.append(
+                ib_insync.ComboLeg(
+                    conId=long_contract.conId,
+                    ratio=1,
+                    action="BUY",
+                    exchange=long_contract.exchange,
+                )
+            )
+            combo_contract.comboLegs.append(
+                ib_insync.ComboLeg(
+                    conId=short_contract.conId,
+                    ratio=1,
+                    action="SELL",
+                    exchange=short_contract.exchange,
+                )
+            )
 
             # Create a test order for whatIf check
             test_order = LimitOrder(
@@ -418,9 +443,23 @@ class VerticalSpreadExecutor:
             short_contract = self.ibkr_client._get_qqq_option_contract(strike_short, short_right)
 
             # Create combo contract for spread
-            combo_contract = ib_insync.Bag("QQQ", "SMART", "USD")
-            combo_contract.addLeg(long_contract, 1)
-            combo_contract.addLeg(short_contract, -1)
+            combo_contract = ib_insync.Bag(symbol="QQQ", exchange="SMART", currency="USD")
+            combo_contract.comboLegs.append(
+                ib_insync.ComboLeg(
+                    conId=long_contract.conId,
+                    ratio=1,
+                    action="BUY",
+                    exchange=long_contract.exchange,
+                )
+            )
+            combo_contract.comboLegs.append(
+                ib_insync.ComboLeg(
+                    conId=short_contract.conId,
+                    ratio=1,
+                    action="SELL",
+                    exchange=short_contract.exchange,
+                )
+            )
 
             # Start with initial MID price as limit
             current_limit_price = initial_mid_price
@@ -587,7 +626,18 @@ class VerticalSpreadExecutor:
             }
 
         except Exception as e:
-            logger.error(f"Error in limit-ladder execution for follower {follower_id}: {e}")
+            logger.error(
+                f"Error in limit-ladder execution for follower {follower_id}: {e}",
+                exc_info=True,
+            )
+            # Publish alert so upstream observers see the execution failure;
+            # the inner catch previously swallowed the signal silently.
+            await self._publish_alert(
+                follower_id=follower_id,
+                message=f"GATEWAY_UNREACHABLE: {e!s}",
+                alert_type=AlertType.GATEWAY_UNREACHABLE,
+                severity=AlertSeverity.CRITICAL,
+            )
             return {
                 "status": OrderStatus.REJECTED,
                 "error": f"Limit-ladder execution error: {e!s}",


### PR DESCRIPTION
## Summary
- Restore green state for `tests/unit/test_executor_alerts.py` (7/7 pass) by aligning `trading-bot/app/service/executor.py` with the actually-installed `ib_insync==0.9.86` API.
- The installed `Bag.__init__` signature is `(self, **kwargs)` and the class no longer exposes `addLeg(...)`. The production code still uses the older positional form plus `addLeg`, so every whatIf margin check raises `TypeError` / `AttributeError` before the alert-publishing code path runs.
- Fix additionally surfaces and repairs three latent bugs that only become observable once the `Bag` TypeError stops masking them; without these the issue's stated AC ("7 tests pass") cannot be met.

## Given / When / Then

**AC-1 — Bag uses the current ib_insync API**
- Given `trading_bot.app.service.executor` running against `ib_insync==0.9.86`
- When `_perform_whatif_margin_check` or `_execute_limit_ladder` build the combo contract
- Then `ib_insync.Bag(symbol=..., exchange=..., currency=...)` is constructed with kwargs and legs are appended as `ib_insync.ComboLeg(conId=..., ratio=1, action="BUY"|"SELL", exchange=...)` on `comboLegs`

**AC-2 — Connection loss raises GATEWAY_UNREACHABLE (not NO_MARGIN)**
- Given `ibkr_client.ensure_connected()` returns `False`
- When `execute_vertical_spread` runs
- Then exactly one alert is published to Redis stream `alerts` with `type == AlertType.GATEWAY_UNREACHABLE` and `"GATEWAY_UNREACHABLE"` in the message

**AC-3 — MID-too-low alert renders threshold with two decimals**
- Given `min_price_threshold=0.70`, MID below threshold
- When `execute_vertical_spread` publishes the MID_TOO_LOW alert
- Then the message contains `"$0.70"` (not `"$0.7"`)

**AC-4 — Exceptions in `_execute_limit_ladder` publish a GATEWAY_UNREACHABLE alert**
- Given `placeOrder` raises `Exception("Order rejected by IB")`
- When the limit-ladder path catches it
- Then a GATEWAY_UNREACHABLE alert is published with the exception message, and the result still has `status == OrderStatus.REJECTED`

**AC-5 — Full suite `TestExecutorAlerts` passes (7/7)**
- Given env vars set as in `pytest.ini`
- When `pytest tests/unit/test_executor_alerts.py`
- Then 7 passed, 0 failed

## Key changes
- `trading-bot/app/service/executor.py`
  - `_perform_whatif_margin_check`: `Bag("QQQ","SMART","USD")` → `Bag(symbol=..., exchange=..., currency=...)`; `bag.addLeg(...)` → explicit `ComboLeg` objects on `comboLegs` with `action="BUY"/"SELL"`.
  - `execute_vertical_spread`: on margin-check failure, "Not connected to IB Gateway" routes to `GATEWAY_UNREACHABLE` alert (was mis-classified as `NO_MARGIN`).
  - `execute_vertical_spread`: MID_TOO_LOW alert formats threshold with `:.2f`.
  - `_execute_limit_ladder`: same Bag/ComboLeg correction as above; plus its `except` now publishes a `GATEWAY_UNREACHABLE` alert instead of silently swallowing the signal.

## Tests added
- No new tests — the existing 7 in `tests/unit/test_executor_alerts.py::TestExecutorAlerts` act as the acceptance suite (all go from red to green).

## Follow-up (out of scope)
Same broken pattern (`Bag("QQQ","SMART","USD")` + `addLeg`) exists in:
- `spreadpilot-core/spreadpilot_core/ibkr/client.py:606-610`
- `trading-bot/tests/unit/test_executor_simple.py:158, 278`

These are not exercised by the 7 tests in this issue — worth a dedicated ticket.

## Checklist
- [x] Tests pass: `pytest tests/unit/test_executor_alerts.py` → 7 passed
- [x] No regression in neighbouring suites (`test_executor_simple.py` 4/4, `test_time_value_monitor.py`, `test_pnl_service.py`)
- [x] `ruff check` clean on the modified file
- [x] `ruff format --check` clean on the modified file
- [x] No user-facing docs affected

Closes #180

🤖 Generated with [Claude Code](https://claude.com/claude-code)