### PR TITLE
fix(test): rewrite test_gateway_manager_vault with async/await (#183)

### DIFF
--- a/tests/unit/test_gateway_manager_vault.py
+++ b/tests/unit/test_gateway_manager_vault.py
@@ -1,9 +1,11 @@
 """Unit tests for GatewayManager Vault integration."""
 
 from dataclasses import dataclass
-from unittest.mock import Mock, patch
+from unittest.mock import AsyncMock, Mock, patch
 
+import pytest
 from spreadpilot_core.ibkr.gateway_manager import GatewayManager, GatewayStatus
+from spreadpilot_core.models.follower import FollowerState
 
 
 @dataclass
@@ -13,6 +15,8 @@ class MockFollower:
     id: str
     ibkr_username: str
     vault_secret_ref: str = None
+    enabled: bool = True
+    state: str = FollowerState.ACTIVE.value
 
 
 class TestGatewayManagerVaultIntegration:
@@ -20,12 +24,14 @@ class TestGatewayManagerVaultIntegration:
 
     def setup_method(self):
         """Set up test fixtures."""
-        self.gateway_manager = GatewayManager(vault_enabled=True)
+        with patch("spreadpilot_core.ibkr.gateway_manager.docker.from_env"):
+            self.gateway_manager = GatewayManager(vault_enabled=True)
+            self.gateway_manager.docker_client = Mock()
 
+    @pytest.mark.asyncio
     @patch("spreadpilot_core.ibkr.gateway_manager.get_vault_client")
-    def test_get_ibkr_credentials_from_vault_success(self, mock_get_vault_client):
+    async def test_get_ibkr_credentials_from_vault_success(self, mock_get_vault_client):
         """Test successful credential retrieval from Vault."""
-        # Arrange
         mock_vault_client = Mock()
         mock_vault_client.get_ibkr_credentials.return_value = {
             "IB_USER": "vault_user",
@@ -33,72 +39,80 @@ class TestGatewayManagerVaultIntegration:
         }
         mock_get_vault_client.return_value = mock_vault_client
 
-        # Act
-        result = self.gateway_manager._get_ibkr_credentials_from_vault("ibkr/test")
+        follower = MockFollower(
+            id="test_follower",
+            ibkr_username="test_user",
+            vault_secret_ref="ibkr/test",
+        )
 
-        # Assert
+        unwrapped = type(self.gateway_manager)._get_ibkr_credentials_from_vault.__wrapped__
+        result = await unwrapped(self.gateway_manager, follower)
+
         assert result == {"IB_USER": "vault_user", "IB_PASS": "vault_pass"}
         mock_vault_client.get_ibkr_credentials.assert_called_once_with("ibkr/test")
 
+    @pytest.mark.asyncio
     @patch("spreadpilot_core.ibkr.gateway_manager.get_vault_client")
-    def test_get_ibkr_credentials_from_vault_not_found(self, mock_get_vault_client):
+    async def test_get_ibkr_credentials_from_vault_not_found(self, mock_get_vault_client):
         """Test credential retrieval when not found in Vault."""
-        # Arrange
         mock_vault_client = Mock()
         mock_vault_client.get_ibkr_credentials.return_value = None
         mock_get_vault_client.return_value = mock_vault_client
 
-        # Act
-        result = self.gateway_manager._get_ibkr_credentials_from_vault("ibkr/test")
+        follower = MockFollower(
+            id="test_follower",
+            ibkr_username="test_user",
+            vault_secret_ref="ibkr/test",
+        )
 
-        # Assert
+        with patch.object(self.gateway_manager, "_publish_alert", new_callable=AsyncMock):
+            unwrapped = type(self.gateway_manager)._get_ibkr_credentials_from_vault.__wrapped__
+            result = await unwrapped(self.gateway_manager, follower)
+
         assert result is None
 
+    @pytest.mark.asyncio
     @patch("spreadpilot_core.ibkr.gateway_manager.get_vault_client")
-    def test_get_ibkr_credentials_from_vault_error(self, mock_get_vault_client):
-        """Test credential retrieval when Vault throws error."""
-        # Arrange
+    async def test_get_ibkr_credentials_from_vault_error(self, mock_get_vault_client):
+        """Test credential retrieval when Vault throws error raises after retries."""
         mock_vault_client = Mock()
         mock_vault_client.get_ibkr_credentials.side_effect = Exception("Vault connection error")
         mock_get_vault_client.return_value = mock_vault_client
 
-        # Act
-        result = self.gateway_manager._get_ibkr_credentials_from_vault("ibkr/test")
+        follower = MockFollower(
+            id="test_follower",
+            ibkr_username="test_user",
+            vault_secret_ref="ibkr/test",
+        )
 
-        # Assert
+        unwrapped = type(self.gateway_manager)._get_ibkr_credentials_from_vault.__wrapped__
+        with pytest.raises(Exception, match="Vault connection error"):
+            await unwrapped(self.gateway_manager, follower)
+
+    @pytest.mark.asyncio
+    async def test_get_ibkr_credentials_from_vault_disabled(self):
+        """Test credential retrieval when Vault is disabled returns None."""
+        with patch("spreadpilot_core.ibkr.gateway_manager.docker.from_env"):
+            gateway_manager = GatewayManager(vault_enabled=False)
+
+        follower = MockFollower(id="test_follower", ibkr_username="test_user")
+
+        unwrapped = type(gateway_manager)._get_ibkr_credentials_from_vault.__wrapped__
+        result = await unwrapped(gateway_manager, follower)
+
         assert result is None
 
-    def test_get_ibkr_credentials_from_vault_disabled(self):
-        """Test credential retrieval when Vault is disabled."""
-        # Arrange
-        gateway_manager = GatewayManager(vault_enabled=False)
+    @pytest.mark.asyncio
+    async def test_start_gateway_with_vault_credentials(self):
+        """Test starting gateway with valid Vault credentials."""
+        import docker as docker_lib
 
-        # Act
-        result = gateway_manager._get_ibkr_credentials_from_vault("ibkr/test")
-
-        # Assert
-        assert result is None
-
-    @patch("spreadpilot_core.ibkr.gateway_manager.docker.from_env")
-    @patch("spreadpilot_core.ibkr.gateway_manager.get_vault_client")
-    def test_start_gateway_with_vault_credentials(self, mock_get_vault_client, mock_docker):
-        """Test starting gateway with Vault credentials."""
-        # Arrange
-        mock_vault_client = Mock()
-        mock_vault_client.get_ibkr_credentials.return_value = {
-            "IB_USER": "vault_user",
-            "IB_PASS": "vault_pass",
-        }
-        mock_get_vault_client.return_value = mock_vault_client
-
-        mock_docker_client = Mock()
         mock_container = Mock()
         mock_container.id = "test_container_id"
-        mock_docker_client.containers.run.return_value = mock_container
-        mock_docker_client.containers.get.side_effect = Exception(
+        self.gateway_manager.docker_client.containers.run.return_value = mock_container
+        self.gateway_manager.docker_client.containers.get.side_effect = docker_lib.errors.NotFound(
             "Not found"
-        )  # No existing container
-        mock_docker.return_value = mock_docker_client
+        )
 
         follower = MockFollower(
             id="test_follower",
@@ -106,46 +120,61 @@ class TestGatewayManagerVaultIntegration:
             vault_secret_ref="ibkr/test_follower",
         )
 
-        # Mock port and client ID allocation
         with (
-            patch.object(self.gateway_manager, "_allocate_port", return_value=4100),
-            patch.object(self.gateway_manager, "_allocate_client_id", return_value=1000),
+            patch.object(
+                self.gateway_manager,
+                "_get_ibkr_credentials_from_vault",
+                new_callable=AsyncMock,
+                return_value={"IB_USER": "vault_user", "IB_PASS": "vault_pass"},
+            ),
+            patch.object(self.gateway_manager, "_store_gateway_mapping", new_callable=AsyncMock),
         ):
-            # Act
-            gateway = self.gateway_manager._start_gateway(follower)
+            gateway = await self.gateway_manager._start_gateway(follower)
 
-            # Assert
-            assert gateway.follower_id == "test_follower"
-            assert gateway.host_port == 4100
-            assert gateway.client_id == 1000
-            assert gateway.status == GatewayStatus.STARTING
+        assert gateway.follower_id == "test_follower"
+        assert gateway.status == GatewayStatus.STARTING
 
-            # Verify Docker container was started with Vault credentials
-            mock_docker_client.containers.run.assert_called_once()
-            call_args = mock_docker_client.containers.run.call_args
-            environment = call_args[1]["environment"]
-            assert environment["IB_USER"] == "vault_user"
-            assert environment["IB_PASS"] == "vault_pass"
+        call_args = self.gateway_manager.docker_client.containers.run.call_args
+        environment = call_args[1]["environment"]
+        assert environment["IB_USER"] == "vault_user"
+        assert environment["IB_PASS"] == "vault_pass"
 
-    @patch("spreadpilot_core.ibkr.gateway_manager.docker.from_env")
-    @patch("spreadpilot_core.ibkr.gateway_manager.get_vault_client")
-    def test_start_gateway_vault_fallback_to_stored_credentials(
-        self, mock_get_vault_client, mock_docker
-    ):
-        """Test starting gateway falls back to stored credentials when Vault fails."""
-        # Arrange
-        mock_vault_client = Mock()
-        mock_vault_client.get_ibkr_credentials.return_value = None  # Vault credentials not found
-        mock_get_vault_client.return_value = mock_vault_client
+    @pytest.mark.asyncio
+    async def test_start_gateway_vault_returns_none_raises(self):
+        """Test that _start_gateway raises when Vault returns no credentials."""
+        follower = MockFollower(
+            id="test_follower",
+            ibkr_username="stored_user",
+            vault_secret_ref="ibkr/test_follower",
+        )
 
-        mock_docker_client = Mock()
-        mock_container = Mock()
-        mock_container.id = "test_container_id"
-        mock_docker_client.containers.run.return_value = mock_container
-        mock_docker_client.containers.get.side_effect = Exception(
-            "Not found"
-        )  # No existing container
-        mock_docker.return_value = mock_docker_client
+        with (
+            patch.object(
+                self.gateway_manager,
+                "_get_ibkr_credentials_from_vault",
+                new_callable=AsyncMock,
+                return_value=None,
+            ),
+            patch.object(self.gateway_manager, "_publish_alert", new_callable=AsyncMock),
+        ):
+            with pytest.raises(ValueError, match="Failed to retrieve Vault credentials"):
+                await self.gateway_manager._start_gateway(follower)
+
+    @pytest.mark.asyncio
+    async def test_start_gateway_no_vault_secret_ref_raises(self):
+        """Test that _start_gateway raises when follower has no vault_secret_ref."""
+        follower = MockFollower(id="test_follower", ibkr_username="stored_user")
+
+        with patch.object(self.gateway_manager, "_publish_alert", new_callable=AsyncMock):
+            with pytest.raises(ValueError, match="Failed to retrieve Vault credentials"):
+                await self.gateway_manager._start_gateway(follower)
+
+    @pytest.mark.asyncio
+    async def test_start_gateway_vault_disabled_raises(self):
+        """Test that _start_gateway raises when Vault is disabled (no credentials available)."""
+        with patch("spreadpilot_core.ibkr.gateway_manager.docker.from_env"):
+            gateway_manager = GatewayManager(vault_enabled=False)
+            gateway_manager.docker_client = Mock()
 
         follower = MockFollower(
             id="test_follower",
@@ -153,106 +182,28 @@ class TestGatewayManagerVaultIntegration:
             vault_secret_ref="ibkr/test_follower",
         )
 
-        # Mock port and client ID allocation
-        with (
-            patch.object(self.gateway_manager, "_allocate_port", return_value=4100),
-            patch.object(self.gateway_manager, "_allocate_client_id", return_value=1000),
-        ):
-            # Act
-            gateway = self.gateway_manager._start_gateway(follower)
-
-            # Assert
-            mock_docker_client.containers.run.assert_called_once()
-            call_args = mock_docker_client.containers.run.call_args
-            environment = call_args[1]["environment"]
-            assert environment["IB_USER"] == "stored_user"
-            assert environment["IB_PASS"] == "placeholder"  # Fallback password
-
-    @patch("spreadpilot_core.ibkr.gateway_manager.docker.from_env")
-    def test_start_gateway_no_vault_secret_ref(self, mock_docker):
-        """Test starting gateway without Vault secret reference uses stored credentials."""
-        # Arrange
-        mock_docker_client = Mock()
-        mock_container = Mock()
-        mock_container.id = "test_container_id"
-        mock_docker_client.containers.run.return_value = mock_container
-        mock_docker_client.containers.get.side_effect = Exception(
-            "Not found"
-        )  # No existing container
-        mock_docker.return_value = mock_docker_client
-
-        follower = MockFollower(
-            id="test_follower",
-            ibkr_username="stored_user",
-            # No vault_secret_ref
-        )
-
-        # Mock port and client ID allocation
-        with (
-            patch.object(self.gateway_manager, "_allocate_port", return_value=4100),
-            patch.object(self.gateway_manager, "_allocate_client_id", return_value=1000),
-        ):
-            # Act
-            gateway = self.gateway_manager._start_gateway(follower)
-
-            # Assert
-            mock_docker_client.containers.run.assert_called_once()
-            call_args = mock_docker_client.containers.run.call_args
-            environment = call_args[1]["environment"]
-            assert environment["IB_USER"] == "stored_user"
-            assert environment["IB_PASS"] == "placeholder"  # Fallback password
-
-    @patch("spreadpilot_core.ibkr.gateway_manager.docker.from_env")
-    def test_start_gateway_vault_disabled(self, mock_docker):
-        """Test starting gateway with Vault disabled uses stored credentials."""
-        # Arrange
-        gateway_manager = GatewayManager(vault_enabled=False)
-
-        mock_docker_client = Mock()
-        mock_container = Mock()
-        mock_container.id = "test_container_id"
-        mock_docker_client.containers.run.return_value = mock_container
-        mock_docker_client.containers.get.side_effect = Exception(
-            "Not found"
-        )  # No existing container
-        mock_docker.return_value = mock_docker_client
-
-        follower = MockFollower(
-            id="test_follower",
-            ibkr_username="stored_user",
-            vault_secret_ref="ibkr/test_follower",
-        )
-
-        # Mock port and client ID allocation
-        with (
-            patch.object(gateway_manager, "_allocate_port", return_value=4100),
-            patch.object(gateway_manager, "_allocate_client_id", return_value=1000),
-        ):
-            # Act
-            gateway = gateway_manager._start_gateway(follower)
-
-            # Assert
-            mock_docker_client.containers.run.assert_called_once()
-            call_args = mock_docker_client.containers.run.call_args
-            environment = call_args[1]["environment"]
-            assert environment["IB_USER"] == "stored_user"
-            assert environment["IB_PASS"] == "placeholder"  # Fallback password
+        with patch.object(gateway_manager, "_publish_alert", new_callable=AsyncMock):
+            with pytest.raises(ValueError, match="Failed to retrieve Vault credentials"):
+                await gateway_manager._start_gateway(follower)
 
 
 class TestGatewayManagerVaultConfiguration:
     """Test GatewayManager Vault configuration."""
 
-    def test_gateway_manager_vault_enabled_by_default(self):
+    @patch("spreadpilot_core.ibkr.gateway_manager.docker.from_env")
+    def test_gateway_manager_vault_enabled_by_default(self, _mock_docker):
         """Test that Vault is enabled by default."""
         gateway_manager = GatewayManager()
         assert gateway_manager.vault_enabled is True
 
-    def test_gateway_manager_vault_can_be_disabled(self):
+    @patch("spreadpilot_core.ibkr.gateway_manager.docker.from_env")
+    def test_gateway_manager_vault_can_be_disabled(self, _mock_docker):
         """Test that Vault can be disabled."""
         gateway_manager = GatewayManager(vault_enabled=False)
         assert gateway_manager.vault_enabled is False
 
-    def test_gateway_manager_other_parameters_unchanged(self):
+    @patch("spreadpilot_core.ibkr.gateway_manager.docker.from_env")
+    def test_gateway_manager_other_parameters_unchanged(self, _mock_docker):
         """Test that other parameters work normally with Vault integration."""
         gateway_manager = GatewayManager(
             gateway_image="custom:latest",


### PR DESCRIPTION
## Summary
- Rewrite all 11 tests in `tests/unit/test_gateway_manager_vault.py` to match current async production API — no production code changes.
- Root causes: sync tests calling async methods without `await`, wrong argument type (string vs Follower object), missing Docker/Redis mocks, stale "fallback credentials" assertions that no longer match production behavior.
- Result: 11/11 tests pass (8 integration + 3 configuration).

## Key changes

| Test | What changed |
|------|-------------|
| `test_get_ibkr_credentials_from_vault_success` | Made async, pass `MockFollower` instead of string, bypass `@backoff` via `__wrapped__` |
| `test_get_ibkr_credentials_from_vault_not_found` | Same + mock `_publish_alert` (called on not-found path) |
| `test_get_ibkr_credentials_from_vault_error` | Expect `pytest.raises(Exception)` — method raises after retry, doesn't return None |
| `test_get_ibkr_credentials_from_vault_disabled` | Made async, mock Docker in constructor |
| `test_start_gateway_with_vault_credentials` | Made async, mock `_get_ibkr_credentials_from_vault` + `_store_gateway_mapping` as `AsyncMock` |
| `test_start_gateway_vault_fallback_*` → `vault_returns_none_raises` | **Replaced**: prod no longer falls back to stored credentials — raises `ValueError` |
| `test_start_gateway_no_vault_secret_ref` → `_raises` | **Replaced**: expects `ValueError` instead of fallback |
| `test_start_gateway_vault_disabled` → `_raises` | **Replaced**: expects `ValueError` instead of fallback |
| `TestGatewayManagerVaultConfiguration` (3 tests) | Mock `docker.from_env` to avoid real Docker daemon |

## Checklist
- [x] 11/11 tests pass
- [x] `ruff check` clean
- [x] `ruff format --check` clean
- [x] No production code modified

Fixes #183

🤖 Generated with [Claude Code](https://claude.com/claude-code)