### PR TITLE
fix(report-worker): fix MinIO config, logger kwargs, and test mocks (#185)

### DIFF
--- a/report-worker/app/service/minio_service.py
+++ b/report-worker/app/service/minio_service.py
@@ -7,9 +7,6 @@ import boto3
 from botocore.exceptions import ClientError, NoCredentialsError
 from spreadpilot_core.logging.logger import get_logger
 
-# Import the module, not the attributes (to avoid triggering __getattr__ at import time)
-from .. import config
-
 logger = get_logger(__name__)
 
 
@@ -17,14 +14,13 @@ class MinIOService:
     """Service for uploading reports to MinIO/S3 with lifecycle management."""
 
     def __init__(self):
-        """Initialize MinIO service with configuration."""
-        # Access settings via config module (triggers __getattr__ at runtime, not import time)
-        self.endpoint_url = config.MINIO_ENDPOINT_URL
-        self.access_key = config.MINIO_ACCESS_KEY
-        self.secret_key = config.MINIO_SECRET_KEY
-        self.bucket_name = config.MINIO_BUCKET_NAME
-        self.region = config.MINIO_REGION
-        self.secure = config.MINIO_SECURE
+        """Initialize MinIO service with configuration from environment."""
+        self.endpoint_url = os.environ.get("MINIO_ENDPOINT_URL")
+        self.access_key = os.environ.get("MINIO_ACCESS_KEY")
+        self.secret_key = os.environ.get("MINIO_SECRET_KEY")
+        self.bucket_name = os.environ.get("MINIO_BUCKET_NAME")
+        self.region = os.environ.get("MINIO_REGION", "us-east-1")
+        self.secure = os.environ.get("MINIO_SECURE", "true").lower() == "true"
 
         self._s3_client = None
 

--- a/report-worker/app/service/notifier_minio.py
+++ b/report-worker/app/service/notifier_minio.py
@@ -6,7 +6,6 @@ from spreadpilot_core.logging.logger import get_logger
 from spreadpilot_core.models.follower import Follower
 from spreadpilot_core.utils.email import send_email
 
-from .. import config
 from .minio_service import get_minio_service
 
 logger = get_logger(__name__)
@@ -83,7 +82,7 @@ def send_report_email_with_minio(
             body = f"""
             <html>
             <body>
-                <p>Dear {follower.name if hasattr(follower, 'name') else 'Valued Client'},</p>
+                <p>Dear {follower.name if hasattr(follower, "name") else "Valued Client"},</p>
                 
                 <p>Your monthly report for {report_period} is ready.</p>
                 
@@ -111,7 +110,7 @@ def send_report_email_with_minio(
             body = f"""
             <html>
             <body>
-                <p>Dear {follower.name if hasattr(follower, 'name') else 'Valued Client'},</p>
+                <p>Dear {follower.name if hasattr(follower, "name") else "Valued Client"},</p>
                 
                 <p>Please find attached your monthly report for {report_period}.</p>
                 
@@ -138,12 +137,13 @@ def send_report_email_with_minio(
 
         # Determine CC recipients
         cc_recipients = []
-        if config.ADMIN_EMAIL:
-            cc_recipients.append(config.ADMIN_EMAIL)
+        admin_email = os.environ.get("ADMIN_EMAIL")
+        if admin_email:
+            cc_recipients.append(admin_email)
 
         # Send email using core utility
         result = send_email(
-            from_email=config.REPORT_SENDER_EMAIL,
+            from_email=os.environ.get("REPORT_SENDER_EMAIL", "noreply@spreadpilot.com"),
             to_email=follower.email,
             subject=subject,
             html_content=body,

--- a/report-worker/app/service/report_service_enhanced.py
+++ b/report-worker/app/service/report_service_enhanced.py
@@ -1,13 +1,13 @@
 """Enhanced report service with MinIO integration and database updates."""
 
 import datetime
+import os
 
 from motor.motor_asyncio import AsyncIOMotorDatabase
 from spreadpilot_core.db.mongodb import get_mongo_db
 from spreadpilot_core.logging.logger import get_logger
 from spreadpilot_core.models.follower import Follower
 
-import os
 from . import generator, pnl
 from .notifier_minio import send_report_email_with_minio
 

--- a/report-worker/app/service/report_service_enhanced.py
+++ b/report-worker/app/service/report_service_enhanced.py
@@ -7,7 +7,7 @@ from spreadpilot_core.db.mongodb import get_mongo_db
 from spreadpilot_core.logging.logger import get_logger
 from spreadpilot_core.models.follower import Follower
 
-from .. import config
+import os
 from . import generator, pnl
 from .notifier_minio import send_report_email_with_minio
 
@@ -132,7 +132,7 @@ class EnhancedReportService:
                 commission_pct = (
                     follower.commission_pct
                     if follower.commission_pct is not None
-                    else config.DEFAULT_COMMISSION_PERCENTAGE
+                    else float(os.environ.get("DEFAULT_COMMISSION_PERCENTAGE", "20.0"))
                 )
                 commission_amount = pnl.calculate_commission(total_monthly_pnl, follower)
 

--- a/spreadpilot-core/spreadpilot_core/utils/email.py
+++ b/spreadpilot-core/spreadpilot_core/utils/email.py
@@ -60,8 +60,7 @@ class EmailSender:
 
         logger.info(
             "Initialized email sender",
-            from_email=from_email,
-            from_name=from_name,
+            extra={"from_email": from_email, "from_name": from_name},
         )
 
     @dry_run("email", return_value=True, log_args=False)
@@ -119,8 +118,7 @@ class EmailSender:
                     if not os.path.exists(attachment_path):
                         logger.warning(
                             f"Attachment file not found: {attachment_path}",
-                            to_email=to_email,
-                            subject=subject,
+                            extra={"to_email": to_email, "subject": subject},
                         )
                         continue
 
@@ -159,25 +157,28 @@ class EmailSender:
             if response.status_code in [200, 201, 202]:
                 logger.info(
                     "Email sent successfully",
-                    to_email=to_email,
-                    subject=subject,
-                    status_code=response.status_code,
+                    extra={
+                        "to_email": to_email,
+                        "subject": subject,
+                        "status_code": response.status_code,
+                    },
                 )
                 return True
             else:
                 logger.error(
                     "Failed to send email",
-                    to_email=to_email,
-                    subject=subject,
-                    status_code=response.status_code,
-                    response_body=response.body,
+                    extra={
+                        "to_email": to_email,
+                        "subject": subject,
+                        "status_code": response.status_code,
+                        "response_body": response.body,
+                    },
                 )
                 return False
         except Exception as e:
             logger.error(
                 f"Error sending email: {e}",
-                to_email=to_email,
-                subject=subject,
+                extra={"to_email": to_email, "subject": subject},
             )
             return False
 
@@ -228,10 +229,12 @@ class SMTPEmailSender:
 
         logger.info(
             "Initialized SMTP email sender",
-            smtp_host=self.smtp_host,
-            smtp_port=self.smtp_port,
-            from_email=from_email,
-            from_name=from_name,
+            extra={
+                "smtp_host": self.smtp_host,
+                "smtp_port": self.smtp_port,
+                "from_email": from_email,
+                "from_name": from_name,
+            },
         )
 
     @dry_run_async("email", return_value=True, log_args=False)
@@ -325,18 +328,14 @@ class SMTPEmailSender:
 
             logger.info(
                 "Email sent successfully via SMTP",
-                to_email=to_email,
-                subject=subject,
-                smtp_host=self.smtp_host,
+                extra={"to_email": to_email, "subject": subject, "smtp_host": self.smtp_host},
             )
             return True
 
         except Exception as e:
             logger.error(
                 f"Error sending email via SMTP: {e}",
-                to_email=to_email,
-                subject=subject,
-                smtp_host=self.smtp_host,
+                extra={"to_email": to_email, "subject": subject, "smtp_host": self.smtp_host},
             )
             return False
 

--- a/tests/unit/test_report_worker_minio.py
+++ b/tests/unit/test_report_worker_minio.py
@@ -34,28 +34,26 @@ def temp_files():
 def test_follower():
     """Create a test follower."""
     return Follower(
-        id="test_follower_123",
-        name="Test User",
+        _id="test_follower_123",
         email="test@example.com",
-        enabled=True,
+        iban="DE89370400440532013000",
+        ibkr_username="test_trader",
+        ibkr_secret_ref="sm://projects/test/secrets/ibkr_pass",
         commission_pct=20.0,
+        enabled=True,
     )
 
 
 class TestMinIOService:
     """Test MinIO service functionality."""
 
-    @mock_aws
     def test_minio_upload_success(self, temp_files):
         """Test successful MinIO upload."""
         pdf_path, excel_path = temp_files
 
-        # Mock MinIO configuration
         with patch.dict(
             os.environ,
             {
-                "GOOGLE_CLOUD_PROJECT": "test-project",
-                "REPORT_SENDER_EMAIL": "test@example.com",
                 "MINIO_ENDPOINT_URL": "http://localhost:9000",
                 "MINIO_ACCESS_KEY": "test_access",
                 "MINIO_SECRET_KEY": "test_secret",
@@ -63,25 +61,14 @@ class TestMinIOService:
             },
         ):
             service = MinIOService()
-
-            # Test configuration
             assert service.is_configured() is True
 
-            # Create mock S3 bucket
-            import boto3
+            mock_s3 = MagicMock()
+            service._s3_client = mock_s3
 
-            s3_client = boto3.client(
-                "s3",
-                endpoint_url="http://localhost:9000",
-                aws_access_key_id="test_access",
-                aws_secret_access_key="test_secret",
-                region_name="us-east-1",
-            )
-            s3_client.create_bucket(Bucket="test-bucket")
-
-            # Test upload
             object_key = service.upload_report(pdf_path, "test/report.pdf")
             assert object_key == "test/report.pdf"
+            mock_s3.put_object.assert_called_once()
 
     def test_minio_not_configured(self):
         """Test MinIO service when not configured."""
@@ -99,7 +86,6 @@ class TestMinIOService:
             result = service.upload_report("/fake/path.pdf", "test.pdf")
             assert result is None
 
-    @mock_aws
     def test_minio_upload_with_url_generation(self, temp_files):
         """Test MinIO upload with URL generation."""
         pdf_path, excel_path = temp_files
@@ -107,8 +93,6 @@ class TestMinIOService:
         with patch.dict(
             os.environ,
             {
-                "GOOGLE_CLOUD_PROJECT": "test-project",
-                "REPORT_SENDER_EMAIL": "test@example.com",
                 "MINIO_ENDPOINT_URL": "http://localhost:9000",
                 "MINIO_ACCESS_KEY": "test_access",
                 "MINIO_SECRET_KEY": "test_secret",
@@ -117,19 +101,10 @@ class TestMinIOService:
         ):
             service = MinIOService()
 
-            # Create mock S3 bucket
-            import boto3
+            mock_s3 = MagicMock()
+            mock_s3.generate_presigned_url.return_value = "https://minio.example.com/signed-url"
+            service._s3_client = mock_s3
 
-            s3_client = boto3.client(
-                "s3",
-                endpoint_url="http://localhost:9000",
-                aws_access_key_id="test_access",
-                aws_secret_access_key="test_secret",
-                region_name="us-east-1",
-            )
-            s3_client.create_bucket(Bucket="test-bucket")
-
-            # Test upload with URL generation
             object_key, presigned_url = service.upload_report_with_url(
                 pdf_path, "test_follower", "2025-06", "pdf"
             )
@@ -157,14 +132,15 @@ class TestEmailWithMinIO:
     """Test email sending with MinIO integration."""
 
     @patch("report_worker.app.service.notifier_minio.send_email")
-    @patch("report_worker.app.service.notifier_minio.minio_service")
+    @patch("report_worker.app.service.notifier_minio.get_minio_service")
     def test_email_with_minio_links(self, mock_minio, mock_send_email, test_follower, temp_files):
         """Test email sending with MinIO download links."""
         pdf_path, excel_path = temp_files
 
-        # Mock MinIO service
-        mock_minio.is_configured.return_value = True
-        mock_minio.upload_report_with_url.side_effect = [
+        # Mock MinIO service instance returned by get_minio_service()
+        mock_svc = mock_minio.return_value
+        mock_svc.is_configured.return_value = True
+        mock_svc.upload_report_with_url.side_effect = [
             ("pdf_key", "https://minio.example.com/pdf_url"),
             ("excel_key", "https://minio.example.com/excel_url"),
         ]
@@ -183,7 +159,7 @@ class TestEmailWithMinIO:
         assert report_info["email_sent"] is True
 
         # Verify MinIO uploads were called
-        assert mock_minio.upload_report_with_url.call_count == 2
+        assert mock_svc.upload_report_with_url.call_count == 2
 
         # Verify email was sent with links
         mock_send_email.assert_called_once()
@@ -196,7 +172,7 @@ class TestEmailWithMinIO:
         assert "valid for 30 days" in html_content
 
     @patch("report_worker.app.service.notifier_minio.send_email")
-    @patch("report_worker.app.service.notifier_minio.minio_service")
+    @patch("report_worker.app.service.notifier_minio.get_minio_service")
     def test_email_with_attachments_fallback(
         self, mock_minio, mock_send_email, test_follower, temp_files
     ):
@@ -204,7 +180,7 @@ class TestEmailWithMinIO:
         pdf_path, excel_path = temp_files
 
         # Mock MinIO service not configured
-        mock_minio.is_configured.return_value = False
+        mock_minio.return_value.is_configured.return_value = False
 
         # Mock email sending
         mock_send_email.return_value = True
@@ -230,7 +206,7 @@ class TestEmailWithMinIO:
         assert any(att["path"] == excel_path for att in attachments)
 
     @patch("report_worker.app.service.notifier_minio.send_email")
-    @patch("report_worker.app.service.notifier_minio.minio_service")
+    @patch("report_worker.app.service.notifier_minio.get_minio_service")
     def test_email_with_minio_upload_failure(
         self, mock_minio, mock_send_email, test_follower, temp_files
     ):
@@ -238,8 +214,9 @@ class TestEmailWithMinIO:
         pdf_path, excel_path = temp_files
 
         # Mock MinIO service configured but upload fails
-        mock_minio.is_configured.return_value = True
-        mock_minio.upload_report_with_url.return_value = (None, None)
+        mock_svc = mock_minio.return_value
+        mock_svc.is_configured.return_value = True
+        mock_svc.upload_report_with_url.return_value = (None, None)
 
         # Mock email sending
         mock_send_email.return_value = True
@@ -270,16 +247,13 @@ class TestEmailWithMinIO:
         assert report_info["email_sent"] is False
 
     def test_email_follower_without_email(self, temp_files):
-        """Test email sending to follower without email."""
+        """Test email sending to follower without email attribute."""
         pdf_path, excel_path = temp_files
 
-        # Create follower without email
-        follower = Follower(
-            id="test_follower",
-            name="Test User",
-            enabled=True,
-            # email field missing
-        )
+        # Use a simple mock without email attribute to simulate the missing-email path
+        follower = MagicMock(spec=[])
+        follower.id = "test_follower"
+        follower.email = None
 
         success, report_info = send_report_email_with_minio(
             follower, "2025-06", pdf_path, excel_path
@@ -384,23 +358,37 @@ class TestReportServiceEnhanced:
         # Mock follower data
         follower_doc = {
             "_id": "test_follower",
-            "name": "Test User",
             "email": "test@example.com",
-            "enabled": True,
+            "iban": "DE89370400440532013000",
+            "ibkr_username": "test_trader",
+            "ibkr_secret_ref": "sm://projects/test/secrets/ibkr_pass",
             "commission_pct": 20.0,
+            "enabled": True,
         }
-        mock_db.__getitem__.return_value.find.return_value = AsyncMock()
-        mock_db.__getitem__.return_value.find.return_value.__aiter__ = AsyncMock(
-            return_value=iter([follower_doc])
-        )
 
-        # Mock P&L calculation
-        mock_pnl.calculate_monthly_pnl.return_value = 1000.0
+        # Create a proper async iterator for the cursor
+        class AsyncCursor:
+            def __init__(self, docs):
+                self._docs = iter(docs)
+
+            def __aiter__(self):
+                return self
+
+            async def __anext__(self):
+                try:
+                    return next(self._docs)
+                except StopIteration:
+                    raise StopAsyncIteration
+
+        mock_db.__getitem__.return_value.find.return_value = AsyncCursor([follower_doc])
+
+        # Mock P&L calculation (calculate_monthly_pnl is async)
+        mock_pnl.calculate_monthly_pnl = AsyncMock(return_value=1000.0)
         mock_pnl.calculate_commission.return_value = 200.0
 
-        # Mock report generation
-        mock_generator.generate_pdf_report.return_value = "/fake/report.pdf"
-        mock_generator.generate_excel_report.return_value = "/fake/report.xlsx"
+        # Mock report generation (async functions)
+        mock_generator.generate_pdf_report = AsyncMock(return_value="/fake/report.pdf")
+        mock_generator.generate_excel_report = AsyncMock(return_value="/fake/report.xlsx")
 
         # Mock email sending
         mock_email.return_value = (


### PR DESCRIPTION
## Summary
- Fix 9 test failures in `tests/unit/test_report_worker_minio.py` across 4 root causes: broken config module attribute access, stdlib logger rejecting kwargs, stale Follower model fixtures, and sync mocks where async was needed.
- Includes production fixes in 4 files (MinIO config reads, email logger calls, notifier config, report service config) plus test mock corrections.
- Result: 14/14 tests pass (9 previously broken + 5 previously working).

## Key changes

| File | Change |
|------|--------|
| `report-worker/app/service/minio_service.py` | Read MinIO settings from `os.environ` instead of broken `config.MINIO_*` attr path |
| `report-worker/app/service/notifier_minio.py` | Replace `config.ADMIN_EMAIL`/`config.REPORT_SENDER_EMAIL` with `os.environ.get()` |
| `report-worker/app/service/report_service_enhanced.py` | Replace `config.DEFAULT_COMMISSION_PERCENTAGE` with `os.environ.get()` |
| `spreadpilot-core/spreadpilot_core/utils/email.py` | Convert logger kwargs (`smtp_host=`, `to_email=`) to `extra={}` dicts |
| `tests/unit/test_report_worker_minio.py` | Fix Follower fixtures, MinIO S3 mock, async cursor mock, AsyncMock for async functions, get_minio_service patch |

## Checklist
- [x] 14/14 tests pass
- [x] `ruff check` clean on all 5 files
- [x] `ruff format --check` clean
- [x] Production fixes are minimal and necessary (tests can't pass without them)

Fixes #185

🤖 Generated with [Claude Code](https://claude.com/claude-code)