### PR TITLE
fix(test): mock startup dependencies in test_health_endpoint (#189)

### DIFF
--- a/tests/unit/test_alert_router.py
+++ b/tests/unit/test_alert_router.py
@@ -215,16 +215,27 @@ class TestAlertRouter:
     @pytest.mark.asyncio
     async def test_health_endpoint(self):
         """Test the health check endpoint."""
-        from alert_router.app.alert_router import app
+        from alert_router.app.alert_router import app, router
         from fastapi.testclient import TestClient
 
-        with TestClient(app) as client:
-            response = client.get("/health")
-            assert response.status_code == 200
-            data = response.json()
-            assert data["status"] == "healthy"
-            assert data["service"] == "alert-router"
-            assert "timestamp" in data
+        mock_redis = AsyncMock()
+        mock_redis.xgroup_create = AsyncMock()
+
+        with (
+            patch.object(router, "_init_redis", new_callable=AsyncMock),
+            patch.object(router, "_init_mongo", new_callable=AsyncMock),
+            patch.object(router, "_init_httpx", new_callable=AsyncMock),
+            patch.object(router, "_load_vault_secrets", new_callable=AsyncMock),
+            patch.object(router, "_process_alerts", new_callable=AsyncMock),
+            patch.object(router, "redis_client", mock_redis),
+        ):
+            with TestClient(app) as client:
+                response = client.get("/health")
+                assert response.status_code == 200
+                data = response.json()
+                assert data["status"] == "healthy"
+                assert data["service"] == "alert-router"
+                assert "timestamp" in data
 
     @pytest.mark.asyncio
     async def test_consumer_group_creation(self, alert_router, fake_redis):


### PR DESCRIPTION
## Summary
- Fix `test_health_endpoint` in `tests/unit/test_alert_router.py` which fails with `ServerSelectionTimeoutError` because `TestClient(app)` triggers the FastAPI startup event, calling `router.start()` against real MongoDB/Redis/HTTPX.
- Patch all init methods (`_init_redis`, `_init_mongo`, `_init_httpx`, `_load_vault_secrets`, `_process_alerts`) and provide a mock `redis_client` so no network I/O occurs.
- This is the **last `ci-broken-on-main` issue** — all unit test failures on main should now be resolved.

## Key changes
- `tests/unit/test_alert_router.py`: mock router startup dependencies before `TestClient(app)` context, following the same pattern used in `test_consumer_group_creation`.

## Checklist
- [x] 8/8 alert_router tests pass
- [x] `ruff check` clean
- [x] No production code modified

Fixes #189

🤖 Generated with [Claude Code](https://claude.com/claude-code)