### PR TITLE
fix(admin-api): fix exception order and bare except in WebSocket endpoint (#166)

### DIFF
--- a/admin-api/app/api/v1/endpoints/websocket.py
+++ b/admin-api/app/api/v1/endpoints/websocket.py
@@ -86,34 +86,22 @@ async def websocket_endpoint(websocket: WebSocket, token: str = Query(None)):
         token: JWT token from query parameter
     """
     try:
-        # Validate token before accepting connection
         username = await validate_ws_token(token)
-
-        # Accept connection with authenticated user
-        await manager.connect(websocket, username)
-
-        # Connection loop
-        while True:
-            # Receive and process messages
-            data = await websocket.receive_text()
-
-            # Simple echo for now
-            await manager.send_personal_message(f"You sent: {data}", websocket)
-
-            # In a real application, you would process the message and potentially
-            # broadcast updates to all connected clients
-
     except Exception as auth_error:
-        # Authentication failed - close with 1008 (policy violation)
         logger.warning(f"WebSocket authentication failed: {auth_error}")
         try:
             await websocket.close(code=1008, reason=str(auth_error))
-        except:
-            pass  # Connection may already be closed
+        except (RuntimeError, OSError):
+            pass
+        return
 
+    await manager.connect(websocket, username)
+    try:
+        while True:
+            data = await websocket.receive_text()
+            await manager.send_personal_message(f"You sent: {data}", websocket)
     except WebSocketDisconnect:
         manager.disconnect(websocket)
-
     except Exception as e:
         logger.error(f"WebSocket error: {e}", exc_info=True)
         manager.disconnect(websocket)

--- a/tests/unit/test_websocket_exceptions.py
+++ b/tests/unit/test_websocket_exceptions.py
@@ -1,0 +1,110 @@
+"""Unit tests for WebSocket endpoint exception handling (issue #166).
+
+Imports the websocket module via importlib to avoid pulling in the full
+admin-api config/settings chain which requires Vault secrets.
+"""
+
+import importlib.util
+import inspect
+import sys
+import types
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from fastapi import WebSocketDisconnect
+
+_WS_PATH = (
+    Path(__file__).resolve().parents[2]
+    / "admin-api"
+    / "app"
+    / "api"
+    / "v1"
+    / "endpoints"
+    / "websocket.py"
+)
+
+
+def _load_websocket_module():
+    """Load the websocket module with a stubbed settings dependency."""
+    app_core_config = types.ModuleType("app.core.config")
+    mock_settings = MagicMock()
+    mock_settings.jwt_secret = "x" * 32
+    mock_settings.jwt_algorithm = "HS256"
+    mock_settings.admin_username = "admin"
+    app_core_config.get_settings = lambda: mock_settings
+
+    app_core = types.ModuleType("app.core")
+    app_mod = types.ModuleType("app")
+    app_api = types.ModuleType("app.api")
+    app_api_v1 = types.ModuleType("app.api.v1")
+    app_api_v1_endpoints = types.ModuleType("app.api.v1.endpoints")
+
+    for name, mod in [
+        ("app", app_mod),
+        ("app.core", app_core),
+        ("app.core.config", app_core_config),
+        ("app.api", app_api),
+        ("app.api.v1", app_api_v1),
+        ("app.api.v1.endpoints", app_api_v1_endpoints),
+    ]:
+        sys.modules.setdefault(name, mod)
+
+    spec = importlib.util.spec_from_file_location("app.api.v1.endpoints.websocket", _WS_PATH)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+_ws_mod = _load_websocket_module()
+
+
+class TestWebSocketExceptionHandling:
+    """Verify correct exception ordering and cleanup in the WebSocket endpoint."""
+
+    @pytest.mark.asyncio
+    async def test_disconnect_cleans_up_connection(self):
+        """WebSocketDisconnect must trigger manager.disconnect — not the auth-error branch."""
+        manager = _ws_mod.manager
+        websocket_endpoint = _ws_mod.websocket_endpoint
+
+        mock_ws = AsyncMock()
+        mock_ws.receive_text = AsyncMock(side_effect=WebSocketDisconnect())
+
+        with patch.object(manager, "connect", new_callable=AsyncMock) as mock_connect:
+            mock_connect.side_effect = lambda ws, user: manager.active_connections.__setitem__(
+                ws, user
+            )
+            with patch.object(
+                _ws_mod, "validate_ws_token", new_callable=AsyncMock, return_value="admin"
+            ):
+                await websocket_endpoint(mock_ws, token="valid_token")
+
+        assert mock_ws not in manager.active_connections
+
+    @pytest.mark.asyncio
+    async def test_auth_failure_closes_with_policy_violation(self):
+        """Auth failure must close with code 1008, not leak into the disconnect branch."""
+        manager = _ws_mod.manager
+        websocket_endpoint = _ws_mod.websocket_endpoint
+
+        mock_ws = AsyncMock()
+        initial_count = len(manager.active_connections)
+
+        with patch.object(
+            _ws_mod,
+            "validate_ws_token",
+            new_callable=AsyncMock,
+            side_effect=Exception("Invalid token"),
+        ):
+            await websocket_endpoint(mock_ws, token="bad_token")
+
+        mock_ws.close.assert_called_once_with(code=1008, reason="Invalid token")
+        assert len(manager.active_connections) == initial_count
+
+    def test_no_bare_except_in_source(self):
+        """Source must not contain bare 'except:' — only typed exception handlers."""
+        source = inspect.getsource(_ws_mod.websocket_endpoint)
+        lines = [line.strip() for line in source.splitlines()]
+        bare_excepts = [line for line in lines if line == "except:"]
+        assert len(bare_excepts) == 0, f"Found bare except: {bare_excepts}"


### PR DESCRIPTION
## Summary
- Fix memory leak in WebSocket endpoint: `except Exception` caught `WebSocketDisconnect` before the dedicated handler, so `manager.disconnect()` never ran and connections leaked from `active_connections`.
- Remove bare `except:` (caught `SystemExit`/`KeyboardInterrupt`), replace with `except (RuntimeError, OSError)`.
- Restructure: separate auth try/except with early return from the connection-loop exception handlers.

## Tests added
- `test_disconnect_cleans_up_connection`: verifies WebSocketDisconnect triggers cleanup
- `test_auth_failure_closes_with_policy_violation`: verifies auth failure closes with code 1008
- `test_no_bare_except_in_source`: static check against bare except

## Checklist
- [x] 3/3 new tests pass
- [x] `ruff check` clean
- [x] `ruff format --check` clean

Fixes #166

🤖 Generated with [Claude Code](https://claude.com/claude-code)