### PR TITLE
refactor(admin-api): remove placeholder echo from WebSocket endpoint (#172)

### DIFF
--- a/admin-api/app/api/v1/endpoints/websocket.py
+++ b/admin-api/app/api/v1/endpoints/websocket.py
@@ -97,9 +97,12 @@ async def websocket_endpoint(websocket: WebSocket, token: str = Query(None)):
 
     await manager.connect(websocket, username)
     try:
+        # Server-push channel: dashboard receives broadcasts via broadcast_update().
+        # We still read from the socket so that client disconnects raise
+        # WebSocketDisconnect and we can release the connection; inbound
+        # messages are intentionally discarded.
         while True:
-            data = await websocket.receive_text()
-            await manager.send_personal_message(f"You sent: {data}", websocket)
+            await websocket.receive_text()
     except WebSocketDisconnect:
         manager.disconnect(websocket)
     except Exception as e:

--- a/tests/unit/test_websocket_exceptions.py
+++ b/tests/unit/test_websocket_exceptions.py
@@ -108,3 +108,25 @@ class TestWebSocketExceptionHandling:
         lines = [line.strip() for line in source.splitlines()]
         bare_excepts = [line for line in lines if line == "except:"]
         assert len(bare_excepts) == 0, f"Found bare except: {bare_excepts}"
+
+    @pytest.mark.asyncio
+    async def test_inbound_messages_are_not_echoed(self):
+        """Client messages are discarded — the dashboard channel is server-push only."""
+        manager = _ws_mod.manager
+        websocket_endpoint = _ws_mod.websocket_endpoint
+
+        # Receive two client messages, then disconnect.
+        mock_ws = AsyncMock()
+        mock_ws.receive_text = AsyncMock(side_effect=["hello", "world", WebSocketDisconnect()])
+
+        with patch.object(manager, "connect", new_callable=AsyncMock) as mock_connect:
+            mock_connect.side_effect = lambda ws, user: manager.active_connections.__setitem__(
+                ws, user
+            )
+            with patch.object(
+                _ws_mod, "validate_ws_token", new_callable=AsyncMock, return_value="admin"
+            ):
+                await websocket_endpoint(mock_ws, token="valid_token")
+
+        # No echo — send_text must never be called from the receive loop.
+        mock_ws.send_text.assert_not_called()


### PR DESCRIPTION
## Summary
- Remove the `You sent: {data}` echo from `/dashboard` WebSocket — leftover placeholder behavior that served no production purpose.
- The dashboard channel is server-push only: broadcasts happen via `broadcast_update()`. Inbound client messages are now discarded; `receive_text()` stays solely to surface disconnects as `WebSocketDisconnect`.
- Add regression test guarding the no-echo contract.

## Acceptance Criteria
- **Given** a client sends any text on the WebSocket
- **When** the endpoint receives it
- **Then** no response is sent back (`send_text` never called) and the connection stays open until the client disconnects

## Checklist
- [x] 4/4 tests pass (existing 3 + new `test_inbound_messages_are_not_echoed`)
- [x] `ruff check` clean
- [x] `ruff format --check` clean

Closes #172

🤖 Generated with [Claude Code](https://claude.com/claude-code)