### PR TITLE
refactor(trading-bot): require explicit redis_url, remove localhost default (#175)

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -30,3 +30,4 @@ env =
     ADMIN_USERNAME=admin
     ADMIN_PASSWORD_HASH=$2b$12$test.hash
     GOOGLE_APPLICATION_CREDENTIALS=/tmp/test-credentials.json
+    REDIS_URL=redis://fake:6379

--- a/tests/unit/test_executor_alerts.py
+++ b/tests/unit/test_executor_alerts.py
@@ -43,7 +43,7 @@ def mock_ibkr_client():
 @pytest.fixture
 async def executor(mock_ibkr_client, fake_redis):
     """Create an executor instance with mocked dependencies."""
-    executor = VerticalSpreadExecutor(mock_ibkr_client)
+    executor = VerticalSpreadExecutor(mock_ibkr_client, redis_url="redis://fake")
     executor.redis_client = fake_redis
     yield executor
 

--- a/tests/unit/test_time_value_monitor.py
+++ b/tests/unit/test_time_value_monitor.py
@@ -56,7 +56,7 @@ def mock_ibkr_client():
 @pytest.fixture
 async def tv_monitor(mock_service, fake_redis):
     """Create a time value monitor instance."""
-    monitor = TimeValueMonitor(mock_service)
+    monitor = TimeValueMonitor(mock_service, redis_url="redis://fake")
     monitor.redis_client = fake_redis
     yield monitor
     # Cleanup

--- a/trading-bot/app/config.py
+++ b/trading-bot/app/config.py
@@ -107,6 +107,13 @@ class Settings(BaseSettings):
         description="Timeout in seconds for each limit order attempt",
     )
 
+    # Redis
+    redis_url: str = Field(
+        ...,
+        env="REDIS_URL",
+        description="Redis connection URL (required; no default to surface misconfiguration early)",
+    )
+
     # Polling parameters
     polling_interval_seconds: float = Field(
         default=1.0,

--- a/trading-bot/app/service/base.py
+++ b/trading-bot/app/service/base.py
@@ -78,7 +78,7 @@ class TradingService:
         self.alert_manager = AlertManager(self)
         self.signal_processor = SignalProcessor(self)
         self.pnl_service = PnLService(self)
-        self.time_value_monitor = TimeValueMonitor(self)
+        self.time_value_monitor = TimeValueMonitor(self, redis_url=settings.redis_url)
         self.vertical_spreads_strategy_handler = VerticalSpreadsStrategyHandler(
             self, VERTICAL_SPREADS_STRATEGY
         )

--- a/trading-bot/app/service/executor.py
+++ b/trading-bot/app/service/executor.py
@@ -20,7 +20,7 @@ logger = get_logger(__name__)
 class VerticalSpreadExecutor:
     """Executes vertical spread orders with limit-ladder strategy and margin checks."""
 
-    def __init__(self, ibkr_client: IBKRClient, redis_url: str = "redis://localhost:6379"):
+    def __init__(self, ibkr_client: IBKRClient, redis_url: str):
         """Initialize the executor.
 
         Args:

--- a/trading-bot/app/service/time_value_monitor.py
+++ b/trading-bot/app/service/time_value_monitor.py
@@ -32,7 +32,7 @@ class TimeValueStatus(StrEnum):
 class TimeValueMonitor:
     """Monitor for tracking time value of open positions."""
 
-    def __init__(self, service, redis_url: str = "redis://localhost:6379"):
+    def __init__(self, service, redis_url: str):
         """Initialize the time value monitor.
 
         Args:

--- a/trading-bot/tests/unit/service/test_executor.py
+++ b/trading-bot/tests/unit/service/test_executor.py
@@ -395,7 +395,7 @@ class TestVerticalSpreadExecutor(unittest.TestCase):
 
     def test_executor_initialization(self):
         """Test executor initialization."""
-        executor = VerticalSpreadExecutor(self.mock_ibkr_client)
+        executor = VerticalSpreadExecutor(self.mock_ibkr_client, redis_url="redis://fake")
         self.assertEqual(executor.ibkr_client, self.mock_ibkr_client)
 
     async def test_execute_vertical_spread_bear_call_strategy(self):


### PR DESCRIPTION
## Summary
- `VerticalSpreadExecutor` and `TimeValueMonitor` both defaulted `redis_url` to `redis://localhost:6379`. In Docker/Cloud Run deployments where Redis isn't on localhost, a caller that forgot to pass the URL would silently connect to the wrong host and fail only at trade execution.
- Promote `redis_url` to a required `Settings` field (env `REDIS_URL`, no default); misconfiguration now fails fast at app startup.
- Remove the default from the constructors; `base.py` passes `settings.redis_url` explicitly.

## Acceptance Criteria
- **Given** `REDIS_URL` is not set and the service starts
- **When** `Settings()` is constructed
- **Then** pydantic raises `ValidationError` immediately (no silent localhost fallback)

- **Given** the production trading service
- **When** `TimeValueMonitor` is instantiated from `base.py`
- **Then** it receives `settings.redis_url`, not a hard-coded default

## Key changes
- `trading-bot/app/config.py`: add `redis_url` required field
- `trading-bot/app/service/executor.py`: drop default
- `trading-bot/app/service/time_value_monitor.py`: drop default
- `trading-bot/app/service/base.py`: pass `settings.redis_url`
- Test sites + `pytest.ini`: provide explicit fake URL

## Checklist
- [x] 50/50 tests pass across affected suites
- [x] `ruff check` clean
- [x] `ruff format --check` clean
- [x] CI already defines `REDIS_URL` at workflow level (`ci.yml:113`)

Closes #175

🤖 Generated with [Claude Code](https://claude.com/claude-code)