### PR TITLE
fix(admin-api): replace deprecated 'ismaster' MongoDB command with 'ping' (#174)

### DIFF
--- a/admin-api/app/db/mongodb.py
+++ b/admin-api/app/db/mongodb.py
@@ -36,8 +36,8 @@ async def connect_to_mongo():
         logger.info(f"Connecting to MongoDB at {MONGO_URI}...")
         try:
             _mongo_client = AsyncIOMotorClient(MONGO_URI)
-            # Verify connection
-            await _mongo_client.admin.command("ismaster")
+            # Verify connection (ping replaces deprecated ismaster, removed in MongoDB 6.0)
+            await _mongo_client.admin.command("ping")
             logger.info("MongoDB client initialized successfully.")
         except Exception as e:
             logger.error(f"Failed to initialize MongoDB client: {e}", exc_info=True)
@@ -81,9 +81,9 @@ async def get_db() -> AsyncIOMotorDatabase:
 # Function to check database connection (for health checks)
 async def check_connection():
     try:
-        # The ismaster command is cheap and does not require auth
+        # ping replaces deprecated ismaster (removed in MongoDB 6.0) and requires no auth
         client = get_mongo_client()
-        await client.admin.command("ismaster")
+        await client.admin.command("ping")
         logger.info("Successfully connected to MongoDB!")
         return True
     except Exception as e:

--- a/test_mongodb.py
+++ b/test_mongodb.py
@@ -12,8 +12,8 @@ time.sleep(5)
 # Try to connect to MongoDB
 try:
     client = pymongo.MongoClient(mongo_uri)
-    # The ismaster command is cheap and does not require auth
-    client.admin.command("ismaster")
+    # ping replaces deprecated ismaster (removed in MongoDB 6.0) and requires no auth
+    client.admin.command("ping")
     print("Successfully connected to MongoDB!")
 
     # List databases


### PR DESCRIPTION
## Summary
- `admin-api/app/db/mongodb.py` still called `client.admin.command('ismaster')` in both `connect_to_mongo()` and `check_connection()`. `ismaster` is deprecated since MongoDB 5.0 and removed in 6.0, so health checks emit deprecation warnings today and will break silently on a MongoDB 6.0+ upgrade.
- Switch both call sites to `ping`. The rest of the codebase (trading-bot, alert-router, report-worker, spreadpilot-core) was already on `ping` — only admin-api lagged.
- Also clean up the repo-root ad-hoc script `test_mongodb.py` for consistency.

## Acceptance Criteria
- **Given** MongoDB 6.0+ deployed
- **When** admin-api starts or `/health` is hit
- **Then** connection verification uses `ping`, succeeds, and emits no deprecation warnings

## Key changes
- `admin-api/app/db/mongodb.py` lines 40, 86: `ismaster` → `ping`
- `test_mongodb.py`: same substitution

## Checklist
- [x] 100/100 unit tests pass
- [x] `ruff check` clean
- [x] `ruff format --check` clean
- [x] Existing health test (`admin-api/tests/test_health_endpoints.py`) mocks `admin.command` generically — no test change needed

Closes #174

🤖 Generated with [Claude Code](https://claude.com/claude-code)